### PR TITLE
Add new numeric range filter

### DIFF
--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
@@ -29,7 +29,9 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                     PrivatePropertyName = nameof(Person.Id),
                     IsOrderable = true,
                     IsSearchable = true,
-                    SearchRegex = true
+                    SearchPredicate = (p, s) => s.Contains(p.Id.ToString()),
+                    ColumnSearchPredicateProvider = CreateNumericRangeSearchPredicateProvider(p => p.Id),
+                    ColumnFilter = CreateNumericRangeFilter()
                 },
                 new EnhancedDataTablesColumn<Person, PersonViewModel>
                 {
@@ -68,7 +70,8 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                     PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.Street)}",
                     IsOrderable = true,
                     IsSearchable = true,
-                    SearchPredicate = (p, s) => (p.Location.Street + " " + p.Location.HouseNumber).ToLower().Contains(s.ToLower())
+                    SearchPredicate = (p, s) => (p.Location.Street + " " + p.Location.HouseNumber).ToLower().Contains(s.ToLower()),
+                    ColumnFilter = CreateTextInputFilter()
                 },
                 new EnhancedDataTablesColumn<Person, PersonViewModel>
                 {

--- a/DataTables.NetStandard.Enhanced.Sample/wwwroot/js/jquery.dataTables.yadcf.js
+++ b/DataTables.NetStandard.Enhanced.Sample/wwwroot/js/jquery.dataTables.yadcf.js
@@ -6,7 +6,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 * Yet Another DataTables Column Filter - (yadcf)
 *
 * File:        jquery.dataTables.yadcf.js
-* Version:     0.9.4.beta.25
+* Version:     0.9.4.beta.41
 *
 * Author:      Daniel Reznick
 * Info:        https://github.com/vedmack/yadcf
@@ -28,9 +28,14 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 * -------------
 
 * column_number
-                Required:           true
+                Required:           true (or use column_selector)
                 Type:               int
                 Description:        The number of the column to which the filter will be applied
+
+* column_selector
+                Required:           true (or use column_number)
+                Type:               see https://datatables.net/reference/type/column-selector for valid column-selector formats
+                Description:        The column-selector of the column to which the filter will be applied
 
 * filter_type
                 Required:           false
@@ -76,9 +81,18 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
                 Required:           false
                 Type:               String
                 Default value:      'text'
-                Possible values:    text / html / rendered_html
+                Possible values:    text / html / rendered_html / html5_data_complex
                 Description:        The type of data in column , use "html" when you have some html code in the column (support parsing of multiple elements per cell),
-                                    use rendered_html when you are using render function of columnDefs or similar, that produces a html code, note that both types rendered_html and html have a fallback for simple text parsing
+																		use rendered_html when you are using render function of columnDefs or similar, that produces a html code, note that both types rendered_html and html have a fallback for simple text parsing.
+																		html5_data_complex allows to populate filter with pairs of display/value by using datatables datatables HTML5 data-* attributes - should be used along with specifying html5_data attibute (read docs)
+
+* column_data_render
+                Required:           false
+                Type:               function
+                Possible values:    function (data) {return data.someValue || ('whatever ' + data.otherValue)}
+								Description:        function that will help yadcf to know what is "text" is present in the cell
+								Note:								Originally added to enable cumulative_filtering with column_data_type: "rendered_html"
+								
 
 * text_data_delimiter
                 Required:           false
@@ -113,7 +127,8 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
                 Type:               String
                 Default value:      undefined
                 Possible values:    data-filter / data-search / anything that is supported by datatables
-                Description:        Allows to filter based on data-filter / data-search attributes of the <td> element, read more: http://www.datatables.net/examples/advanced_init/html5-data-attributes.html
+								Description:        Allows to filter based on data-filter / data-search attributes of the <td> element, read more: http://www.datatables.net/examples/advanced_init/html5-data-attributes.html
+								Special notes:			Can be used along with column_data_type: 'html5_data_complex' to populate filter with pairs of display/value instead of values only
 
 * filter_container_id
                 Required:           false
@@ -154,7 +169,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
                 Required:           false
                 Type:               String
                 Default value:      'alpha'
-                Possible values:    alpha / num / alphaNum / none
+                Possible values:    alpha / num / alphaNum / custom / none
                 Description:        Defines how the values in the filter will be sorted, alphabetically / numerically / alphanumeric / custom / not sorted at all (none is useful to preserve
                                     the order of the data attribute as is)
                 Note:               When custom value is set you must provide a custom sorting function for the sort_as_custom_func property
@@ -206,7 +221,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
                 Type:               boolean
                 Default value:      undefined
                 Description:        Adds a checkbox next to the filter that allows to do a "not/exclude" filtering (acts the same  all filter_match_mode)
-                Note:               Currently available for the text filter
+                Note:               Currently available for the text, select and number_range filter
 
 * exclude_label
                 Required:           false
@@ -226,6 +241,21 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
                 Type:               String
                 Default value:      'regex'
 				Description:        The label that will appear above the regex checkbox
+
+* null_check_box
+                Required:           false
+                Type:               boolean
+                Default value:      undefined
+                Description:        Adds a checkbox next to the filter that allows to filter by null value,
+                                    works only for tables with data retrieved via data property, not working for html defined tables,
+                                    where null is represented as string
+                Note:               Currently available for the text and range_number filters
+
+* null_label
+                Required:           false
+                Type:               String
+                Default value:      'null'
+                Description:        The label that will appear above the null checkbox
 
 * checkbox_position_after
                 Required:           false
@@ -248,6 +278,14 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
                 Type:               Object
                 Default value:      {}
                 Description:        This parameter will be passed "as is" to the Chosen/Select2 plugin constructor
+
+* select_null_option
+                Required:           false
+                Type:               string
+                Default value:      'null'
+                Description:        String value which internaly represents null option in select filters,
+                                    also it is send to server if serverside feature is enabled
+                                    Supports exclude, with exclude enabled the string is wrapped with exclude regex
 
 * filter_plugin_options
                 Required:           false
@@ -289,6 +327,24 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
                 Type:               String
                 Description:        Allows adding additional class/classes to filter reset button
 
+* externally_triggered_checkboxes_text
+                Required:           false
+                Default value:      false,
+                Type:               boolean | string
+                Description:        Adds external checkboxes button, and hiddes exclude/null/regex checkboxes
+                                    usecase: hide/show options (checkboxes) button,  checkboxes in popover/modal
+
+* externally_triggered_checkboxes_function
+                Required:           false
+                Default value:      undefined,
+                Type:               function
+                Description:        Adds onclick function to external checkboxes button, with event parameter
+
+* externally_triggered_checkboxes_button_style_class
+                Required:           false
+                Default value:      ''
+                Type:               String
+                Description:        Allows adding additional class/classes to external checkboxes button
 
 * Global Parameters (per table rather than per column)
 *
@@ -335,6 +391,8 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
                 Description:        Calls the provided callback function in the end of the yadcf init function
 				Note:               This callback function will run before datatables fires its event such as draw/xhr/etc., migth be usefull for call some
 									third parties init / loading code
+
+
 * jquery_ui_datepicker_locale
                 Required:           false
                 Type:               string
@@ -343,7 +401,21 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 		Note:               Need to load jquery-ui-i18n lib.
 		Possible values:    af, ar-DZ, ar, az, be, bg, bs, ca, cs, cy-GB, da, de, el, en-AU, en-GB, en-NZ, eo, es, et, eu, fa, fi, fo, fr-CA, fr-CH,
 				    fr, gl, he, hi, hr, hu, hy, id, is, it-CH, it, ja, ka, kk, km, ko, ky, lb, lt, lv, mk, ml, ms, nb, nl-BE, nl, nn, no, pl,
-				    pt-BR, pt, rm, ro, ru, sk, sl, sq, sr-SR, sr, sv, ta, th, tj, tr, uk, vi, zh-CN, zh-HK, zh-TW
+						pt-BR, pt, rm, ro, ru, sk, sl, sq, sr-SR, sr, sv, ta, th, tj, tr, uk, vi, zh-CN, zh-HK, zh-TW
+
+						* null_api_call_value
+                Required:           false
+                Type:               string
+                Default value:      "null"
+                Description:        Value which represents null, and is used as argument for fnFilter function, and sended to server
+				Note:               works with null filter enabled only
+
+* not_null_api_call_value
+                Required:           false
+                Type:               string
+                Default value:      "!^@"
+                Description:        Value which represents not null, and is used as argument for fnFilter function, and sended to server
+				Note:               works with null filter enabled only
 
 *
 *
@@ -396,7 +468,25 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 * exFilterExternallyTriggered
                 Description:        Triggers all the available filters, should be used only when the externally_triggered option used
                 Arguments:          table_arg: (variable of the datatable)
-                Usage example:      yadcf.exResetAllFilters(table_arg);
+								Usage example:      yadcf.exResetAllFilters(table_arg);
+
+* exRefreshColumnFilterWithDataProp
+                Description:        Updates column filter with new data, when data property was used in initialization for this filter
+                                    e.g. select filter, when we used data property and we want to update it
+                Arguments:          table_arg: variable of the datatable
+                                    col_num: number index of column filter
+                                    updatedData: array of new data (use same data structure as was used in yadcf.init options)
+								Usage example:      yadcf.exRefreshColumnFilterWithDataProp(table_arg, 5, ['One', 'Two', 'Three']);
+* initOnDtXhrComplete
+                Description:        Allows to set a callback function to be called after dt xhr finishes
+                Arguments:          function to do some logic
+                Usage example:      yadcf.initOnDtXhrComplete(function() { $("#yadcf-filter--example-0").multiselect('refresh'); });
+
+* initDefaults
+                Description:        Inint global defaults for all yadcf instances.
+                Arguments:          Object consisting of anything defined inside default_options varaible
+                Usage example:      yadcf.initDefaults({language: {select: 'Pick some'}});
+
 *
 *
 *
@@ -514,14 +604,44 @@ if (!Object.entries) {
       selectElementCustomInitFunc,
       selectElementCustomRefreshFunc,
       selectElementCustomDestroyFunc,
-      placeholderLang = {
-        select: 'Select value',
-        select_multi: 'Select values',
-        filter: 'Type to filter',
-        range: ['From', 'To'],
-        date: 'Select a date'
+      default_options = {
+        filter_type: "select",
+        enable_auto_complete: false,
+        sort_as: "alpha",
+        sort_order: "asc",
+        date_format: "mm/dd/yyyy",
+        ignore_char: undefined,
+        filter_match_mode: "contains",
+        select_type: undefined,
+        select_type_options: {},
+        select_null_option: 'null',
+        case_insensitive: true,
+        column_data_type: 'text',
+        html_data_type: 'text',
+        exclude_label: 'exclude',
+        regex_label: 'regex',
+        null_label: 'null',
+        checkbox_position_after: false,
+        style_class: '',
+        reset_button_style_class: '',
+        datepicker_type: 'jquery-ui',
+        range_data_type: 'single',
+        range_data_type_delim: '-',
+        omit_default_label: false,
+        custom_range_delimiter: '-yadcf_delim-',
+        externally_triggered_checkboxes_text: false,
+        externally_triggered_checkboxes_function: undefined,
+        externally_triggered_checkboxes_button_style_class: '',
+        language: {
+          select: 'Select value',
+          select_multi: 'Select values',
+          filter: 'Type to filter',
+          range: ['From', 'To'],
+          date: 'Select a date'
+        }
       },
-      settingsMap = {};
+      settingsMap = {},
+      dTXhrComplete;
 
     var ctrlPressed = false;
     var closeBootstrapDatepicker = false;
@@ -612,6 +732,10 @@ if (!Object.entries) {
       return column_number_obj;
     }
 
+    function initDefaults(params) {
+      return $.extend(true, default_options, params);
+    }
+
     function getOptions(selector) {
       return options[selector];
     }
@@ -631,7 +755,7 @@ if (!Object.entries) {
       var i = 0;
       dot_refs = dot_refs.split(".");
       for (i = 0; i < dot_refs.length; i++) {
-        if (tmpObj[dot_refs[i]]) {
+        if (tmpObj[dot_refs[i]] !== undefined && tmpObj[dot_refs[i]] !== null) {
           tmpObj = tmpObj[dot_refs[i]];
         } else {
           return '';
@@ -643,31 +767,7 @@ if (!Object.entries) {
     function setOptions(selector_arg, options_arg, params, table) {
       var tmpOptions = {},
         i,
-        col_num_as_int,
-        default_options = {
-          filter_type: "select",
-          enable_auto_complete: false,
-          sort_as: "alpha",
-          sort_order: "asc",
-          date_format: "mm/dd/yyyy",
-          ignore_char: undefined,
-          filter_match_mode: "contains",
-          select_type: undefined,
-          select_type_options: {},
-          case_insensitive: true,
-          column_data_type: 'text',
-          html_data_type: 'text',
-          exclude_label: 'exclude',
-          regex_label: 'regex',
-          checkbox_position_after: false,
-          style_class: '',
-          reset_button_style_class: '',
-          datepicker_type: 'jquery-ui',
-          range_data_type: 'single',
-          range_data_type_delim: '-',
-          omit_default_label: false,
-          custom_range_delimiter: '-yadcf_delim-'
-        };
+        col_num_as_int;
       //adaptContainerCssClassImpl = function (dummy) { return ''; };
 
       $.extend(true, default_options, params);
@@ -766,13 +866,13 @@ if (!Object.entries) {
     }
 
     function escapeRegExp(string) {
-      return string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+      return string.replace(/([.*+?^=!:${}()|'\[\]\/\\])/g, "\\$1");
     }
 
     function escapeRegExpInArray(arr) {
       var i;
       for (i = 0; i < arr.length; i++) {
-        arr[i] = arr[i].replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+        arr[i] = arr[i].replace(/([.*+?^=!:${}()|'\[\]\/\\])/g, "\\$1");
       }
       return arr;
     }
@@ -872,6 +972,10 @@ if (!Object.entries) {
       selectElementCustomInitFunc = initFunc;
       selectElementCustomRefreshFunc = refreshFunc;
       selectElementCustomDestroyFunc = destroyFunc;
+    }
+
+    function initOnDtXhrComplete(initFunc) {
+      dTXhrComplete = initFunc;
     }
 
     //Used by exFilterColumn for translating readable search value into proper search string for datatables filtering
@@ -1027,12 +1131,22 @@ if (!Object.entries) {
         selected_value,
         column_number_filter,
         columnObj,
+        exclude_checked = false,
         settingsDt = getSettingsObjFromTable(oTable);
 
       column_number_filter = calcColumnNumberFilter(settingsDt, column_number, table_selector_jq_friendly);
 
       columnObj = getOptions(oTable.selector)[column_number];
+      if (columnObj.exclude) {
+        exclude_checked = $("#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number).find('.yadcf-exclude-wrapper :checkbox').prop('checked');
+      }
+
       if (arg === "clear") {
+        clearStateSave(oTable, column_number, table_selector_jq_friendly);
+        if (exclude_checked) {
+          resetExcludeRegexCheckboxes($("#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number));
+          clearStateSave(oTable, column_number, table_selector_jq_friendly);
+        }
         if (exGetColumnFilterVal(oTable, column_number) === '') {
           return;
         }
@@ -1046,19 +1160,60 @@ if (!Object.entries) {
         return;
       }
 
+      if (arg === "exclude" && $.trim($("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).find('option:selected').val()) === "-1") {
+        return;
+      }
+
       $("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).addClass("inuse");
 
-      $(document).data("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "_val", arg.value);
+      selected_value = $.trim($(arg === "exclude" ? "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number : arg).find('option:selected').val());
 
-      selected_value = $.trim($(arg).find('option:selected').val());
+      $(document).data("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "_val", arg === "exclude" || exclude_checked ? selected_value : arg.value);
 
-      if (arg.value !== "-1") {
-        yadcfMatchFilter(oTable, selected_value, filter_match_mode, column_number_filter, false, column_number);
+      if (arg.value !== "-1" && selected_value !== columnObj.select_null_option) {
+        if (oTable.fnSettings().oFeatures.bServerSide === false) {
+          oTable.fnDraw();
+        }
+        yadcfMatchFilter(oTable, selected_value, filter_match_mode, column_number_filter, exclude_checked, column_number);
+      } else if (selected_value === columnObj.select_null_option) {
+        if (oTable.fnSettings().oFeatures.bServerSide === false) {
+          oTable.fnFilter("", column_number_filter);
+          addNullFilterCapability(table_selector_jq_friendly, column_number, true);
+          oTable.fnDraw();
+        } else {
+          yadcfMatchFilter(oTable, selected_value, filter_match_mode, column_number_filter, exclude_checked, column_number);
+        }
+        if (oTable.fnSettings().oFeatures.bStateSave === true) {
+          stateSaveNullSelect(oTable, columnObj, table_selector_jq_friendly, column_number, filter_match_mode, exclude_checked);
+          oTable.fnSettings().oApi._fnSaveState(oTable.fnSettings());
+        }
       } else {
         oTable.fnFilter("", column_number_filter);
         $("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).removeClass("inuse");
       }
       resetIApiIndex();
+    }
+
+    function stateSaveNullSelect(oTable, columnObj, table_selector_jq_friendly, column_number, filter_match_mode, exclude_checked) {
+      var null_str = columnObj.select_null_option;
+      switch (filter_match_mode) {
+        case "exact":
+          null_str = "^" + escapeRegExp(null_str) + "$";
+          break;
+        case "startsWith":
+          null_str = "^" + escapeRegExp(null_str);
+          break;
+        default:
+          break;
+      }
+      var excludeStrStart = "^((?!";
+      var excludeStrEnd = ").)*$";
+      null_str = exclude_checked ? excludeStrStart + null_str + excludeStrEnd : null_str;
+      if (oTable.fnSettings().oLoadedState) {
+        if (oTable.fnSettings().oLoadedState.yadcfState !== undefined && oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly] !== undefined) {
+          oTable.fnSettings().aoPreSearchCols[column_number].sSearch = null_str;
+        }
+      }
     }
 
     function doFilterMultiSelect(arg, table_selector_jq_friendly, column_number, filter_match_mode) {
@@ -1188,7 +1343,7 @@ if (!Object.entries) {
           if (columnObj.ignore_char !== undefined) {
             array[i] = array[i].toString().replace(columnObj.ignore_char, "");
           }
-          if (columnObj.range_data_type === 'single') {
+          if (columnObj.range_data_type !== 'range') {
             num = +array[i];
           } else {
             num = array[i].split(columnObj.range_data_type_delim);
@@ -1223,7 +1378,7 @@ if (!Object.entries) {
           if (columnObj.ignore_char !== undefined) {
             array[i] = array[i].toString().replace(columnObj.ignore_char, "");
           }
-          if (columnObj.range_data_type === 'single') {
+          if (columnObj.range_data_type !== 'range') {
             num = +array[i];
           } else {
             num = array[i].split(columnObj.range_data_type_delim);
@@ -1258,7 +1413,8 @@ if (!Object.entries) {
           columnObj,
           column_number_filter,
           valFrom,
-          valTo;
+          valTo,
+          exclude_checked = false;
 
         if (table_selector_jq_friendly_local !== current_table_selector_jq_friendly) {
           return true;
@@ -1270,6 +1426,10 @@ if (!Object.entries) {
         } else {
           min = $('#' + fromId).val();
           max = $('#' + toId).val();
+        }
+
+        if (columnObj.exclude) {
+          exclude_checked = $("#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + col_num).find('.yadcf-exclude-wrapper :checkbox').prop('checked');
         }
 
         column_number_filter = calcColumnNumberFilter(settingsDt, col_num, table_selector_jq_friendly);
@@ -1356,36 +1516,81 @@ if (!Object.entries) {
         }
         min = min !== "" ? +min : min;
         max = max !== "" ? +max : max;
-        if (columnObj.range_data_type === 'single') {
-          val = val !== "" ? +val : val;
-          if (min === "" && max === "") {
-            retVal = true;
-          } else if (min === "" && val <= max) {
-            retVal = true;
-          } else if (min <= val && "" === max) {
-            retVal = true;
-          } else if (min <= val && val <= max) {
-            retVal = true;
-          } else if (val === '' || isNaN(val)) {
-            retVal = true;
+        if (!exclude_checked) {
+          if (columnObj.range_data_type === 'single') {
+            val = val !== "" ? +val : val;
+            if (min === "" && max === "") {
+              retVal = true;
+            } else if (min === "" && val <= max) {
+              retVal = true;
+            } else if (min <= val && "" === max) {
+              retVal = true;
+            } else if (min <= val && val <= max) {
+              retVal = true;
+            } else if (val === '' || isNaN(val)) {
+              retVal = true;
+            }
+          } else if (columnObj.range_data_type === 'range') {
+            val = val.split(columnObj.range_data_type_delim);
+            valFrom = val[0] !== "" ? +val[0] : val[0];
+            valTo = val[1] !== "" ? +val[1] : val[1];
+            if (!columnObj.range_data_operator) {
+              if (min === "" && max === "") {
+                retVal = true;
+              } else if (min === "" && valTo <= max) {
+                retVal = true;
+              } else if (min <= valFrom && "" === max) {
+                retVal = true;
+              } else if (min <= valFrom && valTo <= max) {
+                retVal = true;
+              } else if ((valFrom === '' || isNaN(valFrom)) && (valTo === '' || isNaN(valTo))) {
+                retVal = true;
+              }
+            }
+          } else if (columnObj.range_data_type === 'delimiter') {
+            if (columnObj.text_data_delimiter !== undefined) {
+              var valSplitted = val.split(columnObj.text_data_delimiter);
+              var anyNumberInRange = function anyNumberInRange(fromToObj) {
+                return function (element, index, array) {
+                  return element >= fromToObj.from && element <= fromToObj.to;
+                };
+              };
+              retVal = valSplitted.some(anyNumberInRange({ from: min, to: max }));
+            }
           }
-        } else if (columnObj.range_data_type === 'range') {
-          val = val.split(columnObj.range_data_type_delim);
-          valFrom = val[0] !== "" ? +val[0] : val[0];
-          valTo = val[1] !== "" ? +val[1] : val[1];
-          if (min === "" && max === "") {
-            retVal = true;
-          } else if (min === "" && valTo <= max) {
-            retVal = true;
-          } else if (min <= valFrom && "" === max) {
-            retVal = true;
-          } else if (min <= valFrom && valTo <= max) {
-            retVal = true;
-          } else if ((valFrom === '' || isNaN(valFrom)) && (valTo === '' || isNaN(valTo))) {
-            retVal = true;
+          return retVal;
+        } else {
+          if (columnObj.range_data_type === 'single') {
+            val = val !== "" ? +val : val;
+            if (min === "" && max === "") {
+              retVal = true;
+            } else if (min === "" && val > max) {
+              retVal = true;
+            } else if (min > val && "" === max) {
+              retVal = true;
+            } else if (!(min <= val && val <= max) && "" !== max && "" !== min) {
+              retVal = true;
+            } else if (val === '' || isNaN(val)) {
+              retVal = true;
+            }
+          } else if (columnObj.range_data_type === 'range') {
+            val = val.split(columnObj.range_data_type_delim);
+            valFrom = val[0] !== "" ? +val[0] : val[0];
+            valTo = val[1] !== "" ? +val[1] : val[1];
+            if (min === "" && max === "") {
+              retVal = true;
+            } else if (min === "" && valTo > max) {
+              retVal = true;
+            } else if (min > valFrom && "" === max) {
+              retVal = true;
+            } else if (!(min <= valFrom && valTo <= max) && "" !== max && "" !== min) {
+              retVal = true;
+            } else if ((valFrom === '' || isNaN(valFrom)) && (valTo === '' || isNaN(valTo))) {
+              retVal = true;
+            }
           }
+          return retVal;
         }
-        return retVal;
       });
     }
 
@@ -1569,6 +1774,82 @@ if (!Object.entries) {
       });
     }
 
+    function addNullFilterCapability(table_selector_jq_friendly, col_num, isSelect) {
+
+      $.fn.dataTableExt.afnFiltering.push(function (settingsDt, aData, iDataIndex, rowData) {
+        var val,
+          retVal = false,
+          oTable = oTables[table_selector_jq_friendly],
+          table_selector_jq_friendly_local = table_selector_jq_friendly,
+          current_table_selector_jq_friendly = yadcf.generateTableSelectorJQFriendly2(settingsDt),
+          columnObj,
+          column_number_filter,
+          null_checked,
+          exclude_checked;
+
+        if (table_selector_jq_friendly_local !== current_table_selector_jq_friendly) {
+          return true;
+        }
+        columnObj = getOptions(settingsDt.oInstance.selector)[col_num];
+
+        column_number_filter = calcColumnNumberFilter(settingsDt, col_num, table_selector_jq_friendly);
+
+        var fixedPrefix = '';
+        if (settingsDt._fixedHeader !== undefined && $('.fixedHeader-floating').is(":visible")) {
+          fixedPrefix = '.fixedHeader-floating ';
+        }
+        if (columnObj.filters_position === 'tfoot' && settingsDt.nScrollFoot) {
+          fixedPrefix = '.' + settingsDt.nScrollFoot.className + ' ';
+        }
+
+        null_checked = $(fixedPrefix + "#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + col_num).find('.yadcf-null-wrapper :checkbox').prop('checked');
+        null_checked = isSelect ? $.trim($("#yadcf-filter-" + table_selector_jq_friendly + "-" + col_num).find('option:selected').val()) === columnObj.select_null_option : null_checked;
+
+        if (!null_checked) {
+          return true;
+        }
+        if (columnObj.exclude) {
+          exclude_checked = $(fixedPrefix + "#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + col_num).find('.yadcf-exclude-wrapper :checkbox').prop('checked');
+        }
+        if (rowData !== undefined) {
+          // supprort dt render fn, usecase structured data when top is null inner property will return undefined
+          // e.g data = person.cat.name && person.cat = null
+          var rowDataRender = void 0;
+          if (columnObj.column_number_render) {
+            rowDataRender = $.extend(true, [], rowData);
+            var index = columnObj.column_number_data ? columnObj.column_number_data : column_number_filter;
+            var meta = {
+              row: iDataIndex,
+              col: columnObj.column_number,
+              settings: settingsDt
+            };
+            if (typeof index === 'string' && (typeof rowDataRender === 'undefined' ? 'undefined' : _typeof(rowDataRender)) === 'object') {
+              var cellDataRender = columnObj.column_number_render(getProp(rowDataRender, index), 'filter', rowData, meta);
+              setProp(rowDataRender, index, cellDataRender !== undefined ? cellDataRender : getProp(rowData, index));
+            } else {
+              var _cellDataRender2 = columnObj.column_number_render(rowDataRender[index], 'filter', rowData, meta);
+              rowDataRender[index] = _cellDataRender2 !== undefined ? _cellDataRender2 : rowData[index];
+            }
+          }
+          aData = rowDataRender ? rowDataRender : rowData;
+          if (columnObj.column_number_data !== undefined) {
+            column_number_filter = columnObj.column_number_data;
+            val = getProp(aData, column_number_filter);
+          } else {
+            val = aData[column_number_filter];
+          }
+        } else {
+          val = aData[column_number_filter];
+        }
+        if (columnObj.exclude && exclude_checked) {
+          retVal = val === null ? false : true;
+        } else {
+          retVal = val === null ? true : false;
+        }
+        return retVal;
+      });
+    }
+
     function addRangeNumberFilter(filter_selector_string, table_selector_jq_friendly, column_number, filter_reset_button_text, filter_default_label, ignore_char) {
       var fromId = "yadcf-filter-" + table_selector_jq_friendly + "-from-" + column_number,
         toId = "yadcf-filter-" + table_selector_jq_friendly + "-to-" + column_number,
@@ -1576,7 +1857,9 @@ if (!Object.entries) {
         filter_wrapper_id,
         oTable,
         columnObj,
-        filterActionStr;
+        filterActionStr,
+        null_str,
+        exclude_str;
 
       filter_wrapper_id = "yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number;
 
@@ -1605,18 +1888,79 @@ if (!Object.entries) {
       $(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label[1] + "\" id=\"" + toId + "\" class=\"yadcf-filter-range-number yadcf-filter-range\" " + filterActionStr + "></input>");
 
       if (filter_reset_button_text !== false) {
-        $(filter_selector_string_tmp).append("<button type=\"button\" onmousedown=\"yadcf.stopPropagation(event);\" " + "onclick=\"yadcf.stopPropagation(event);yadcf.rangeClear('" + table_selector_jq_friendly + "',event," + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+        $(filter_selector_string_tmp).append("<button type=\"button\" id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset\" onmousedown=\"yadcf.stopPropagation(event);\" " + "onclick=\"yadcf.stopPropagation(event);yadcf.rangeClear('" + table_selector_jq_friendly + "',event," + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
+      }
+
+      if (columnObj.externally_triggered_checkboxes_text && typeof columnObj.externally_triggered_checkboxes_function === 'function') {
+        $(filter_selector_string_tmp).append("<button type=\"button\" " + " id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-externally_triggered_checkboxes-button\" onmousedown=\"yadcf.stopPropagation(event);\" " + "onclick=\"yadcf.stopPropagation(event);\" class=\"yadcf-filter-externally_triggered_checkboxes-button " + columnObj.externally_triggered_checkboxes_button_style_class + "\">" + columnObj.externally_triggered_checkboxes_text + "</button>");
+        $("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-externally_triggered_checkboxes-button").on('click', columnObj.externally_triggered_checkboxes_function);
+      }
+
+      exclude_str = '';
+      if (columnObj.exclude === true) {
+        if (columnObj.externally_triggered !== true) {
+          exclude_str = '<span class="yadcf-exclude-wrapper" onmousedown="yadcf.stopPropagation(event);" onclick="yadcf.stopPropagation(event);">' + '<div class="yadcf-label small">' + columnObj.exclude_label + '</div><input type="checkbox" title="' + columnObj.exclude_label + '" onclick="yadcf.stopPropagation(event);yadcf.rangeNumberKeyUP(\'' + table_selector_jq_friendly + '\',event);"></span>';
+        } else {
+          exclude_str = '<span class="yadcf-exclude-wrapper" onmousedown="yadcf.stopPropagation(event);" onclick="yadcf.stopPropagation(event);">' + '<div class="yadcf-label small">' + columnObj.exclude_label + '</div><input type="checkbox" title="' + columnObj.exclude_label + '" onclick="yadcf.stopPropagation(event);"></span>';
+        }
+      }
+
+      null_str = '';
+      if (columnObj.null_check_box === true) {
+        if (columnObj.externally_triggered !== true) {
+          null_str = '<span class="yadcf-null-wrapper" onmousedown="yadcf.stopPropagation(event);" onclick="yadcf.stopPropagation(event);">' + '<div class="yadcf-label small">' + columnObj.null_label + '</div><input type="checkbox" title="' + columnObj.null_label + '" onclick="yadcf.stopPropagation(event);yadcf.nullChecked(event,\'' + table_selector_jq_friendly + '\',' + column_number + ');"></span>';
+        } else {
+          null_str = '<span class="yadcf-null-wrapper" onmousedown="yadcf.stopPropagation(event);" onclick="yadcf.stopPropagation(event);">' + '<div class="yadcf-label small">' + columnObj.null_label + '</div><input type="checkbox" title="' + columnObj.null_label + '" onclick="yadcf.stopPropagation(event);yadcf.nullChecked(event,\'' + table_selector_jq_friendly + '\',' + column_number + ');"></span>';
+        }
+        if (oTable.fnSettings().oFeatures.bServerSide !== true) {
+          addNullFilterCapability(table_selector_jq_friendly, column_number, false);
+        }
+      }
+
+      var append_checkboxes = columnObj.checkbox_position_after ? exclude_str.replace("yadcf-exclude-wrapper", "yadcf-exclude-wrapper after") + null_str.replace("yadcf-null-wrapper", "yadcf-null-wrapper after") : exclude_str + null_str;
+
+      if (columnObj.checkbox_position_after) {
+        $(filter_selector_string_tmp).append(append_checkboxes);
+      } else {
+        $(filter_selector_string).before(append_checkboxes);
+      }
+      // hide on load
+      if (columnObj.externally_triggered_checkboxes_text && typeof columnObj.externally_triggered_checkboxes_function === 'function') {
+        var sel = $("#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number);
+        sel.find('.yadcf-exclude-wrapper').hide();
+        sel.find('.yadcf-null-wrapper').hide();
       }
 
       if (oTable.fnSettings().oFeatures.bStateSave === true && oTable.fnSettings().oLoadedState) {
         if (oTable.fnSettings().oLoadedState.yadcfState && oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly] && oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number]) {
-          $('#' + fromId).val(oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].from);
-          if (oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].from !== "") {
-            $('#' + fromId).addClass("inuse");
+          var exclude_checked = false;
+          var null_checked = false;
+          if (columnObj.null_check_box) {
+            null_checked = oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].null_checked;
+            $('#' + filter_wrapper_id).find('.yadcf-null-wrapper :checkbox').prop('checked', null_checked);
+            if (columnObj.exclude) {
+              exclude_checked = oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].exclude_checked;
+              $('#' + filter_wrapper_id).find('.yadcf-exclude-wrapper :checkbox').prop('checked', exclude_checked);
+            }
           }
-          $('#' + toId).val(oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].to);
-          if (oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].to !== "") {
-            $('#' + toId).addClass("inuse");
+
+          if (null_checked) {
+            $('#' + fromId).prop('disabled', true);
+            $('#' + toId).prop('disabled', true);
+          } else {
+            var inuseClass = exclude_checked ? ' inuse inuse-exclude' : ' inuse ';
+            if (oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].from) {
+              $('#' + fromId).val(oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].from);
+              if (oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].from !== "") {
+                $('#' + fromId).addClass(inuseClass);
+              }
+            }
+            if (oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].to) {
+              $('#' + toId).val(oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].to);
+              if (oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number].to !== "") {
+                $('#' + toId).addClass(inuseClass);
+              }
+            }
           }
         }
       }
@@ -1843,7 +2187,7 @@ if (!Object.entries) {
         innerWrapperAdditionalClass = 'input-daterange';
       }
       //add a wrapper to hold both filter and reset button
-      $(filter_selector_string).append("<div onmousedown=\"yadcf.stopPropagation(event);\" onclick=\"yadcf.stopPropagation(event);\"  id=\"" + filter_wrapper_id + "\" class=\"yadcf-filter-wrapper " + columnObj.style_class + "\"></div>");
+      $(filter_selector_string).append("<div onmousedown=\"yadcf.stopPropagation(event);\" onclick=\"yadcf.stopPropagation(event);\"  id=\"" + filter_wrapper_id + "\" class=\"yadcf-filter-wrapper \"></div>");
       filter_selector_string += " div.yadcf-filter-wrapper";
       filter_selector_string_tmp = filter_selector_string;
 
@@ -1855,9 +2199,9 @@ if (!Object.entries) {
         filterActionStr = '';
       }
 
-      $(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label[0] + "\" id=\"" + fromId + "\" class=\"yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-start\" " + filterActionStr + "></input>");
+      $(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label[0] + "\" id=\"" + fromId + "\" class=\"yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-start " + columnObj.style_class + "\" " + filterActionStr + "></input>");
       $(filter_selector_string).append("<span class=\"yadcf-filter-range-date-seperator\" >" + "</span>");
-      $(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label[1] + "\" id=\"" + toId + "\" class=\"yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-end\" " + filterActionStr + "></input>");
+      $(filter_selector_string).append("<input onkeydown=\"yadcf.preventDefaultForEnter(event);\" placeholder=\"" + filter_default_label[1] + "\" id=\"" + toId + "\" class=\"yadcf-filter-range-date yadcf-filter-range yadcf-filter-range-end " + columnObj.style_class + "\" " + filterActionStr + "></input>");
 
       $fromInput = $("#" + fromId);
       $toInput = $("#" + toId);
@@ -2376,10 +2720,10 @@ if (!Object.entries) {
       destroyThirdPartyPlugins(oTable);
     }
 
-    /* alphanum.js (C) Brian Huisman
- Based on the Alphanum Algorithm by David Koelle
- The Alphanum Algorithm is discussed at http://www.DaveKoelle.com
-*/
+		/* alphanum.js (C) Brian Huisman
+     Based on the Alphanum Algorithm by David Koelle
+     The Alphanum Algorithm is discussed at http://www.DaveKoelle.com
+  */
     function sortAlphaNum(a, b) {
       function chunkify(t) {
         var tz = [];
@@ -2586,7 +2930,7 @@ if (!Object.entries) {
           } else {
             if (columnObj.column_number_data === undefined) {
               col_inner_data = data[j]._aData[column_number_filter];
-              if ((typeof col_inner_data === 'undefined' ? 'undefined' : _typeof(col_inner_data)) === 'object') {
+              if (col_inner_data !== null && (typeof col_inner_data === 'undefined' ? 'undefined' : _typeof(col_inner_data)) === 'object') {
                 if (columnObj.html5_data !== undefined) {
                   col_inner_data = col_inner_data['@' + columnObj.html5_data];
                 } else if (col_inner_data && col_inner_data.display) {
@@ -2654,14 +2998,29 @@ if (!Object.entries) {
               column_data.push(col_inner_data);
             }
           }
+        } else if (columnObj.column_data_type === "html5_data_complex") {
+          col_inner_data = data[j]._aData[column_number_filter];
+          col_inner_data_helper = col_inner_data['@' + columnObj.html5_data];
+          if (!col_filter_array.hasOwnProperty(col_inner_data_helper)) {
+            col_filter_array[col_inner_data_helper] = col_inner_data_helper;
+            column_data.push({
+              value: col_inner_data_helper,
+              label: col_inner_data['display']
+            });
+          }
         }
       }
       columnObj.col_filter_array = col_filter_array;
+      if (column_data && columnObj.ignore_char !== undefined) {
+        column_data = column_data.map(function (element) {
+          return element.toString().replace(columnObj.ignore_char, "");
+        });
+      }
       return column_data;
     }
 
     function appendFilters(oTable, args, table_selector, pSettings) {
-      var $filter_selector, filter_selector_string, data, filter_container_id, column_number_data, column_number, column_position, filter_default_label, filter_reset_button_text, enable_auto_complete, date_format, ignore_char, filter_match_mode, column_data, column_data_temp, options_tmp, ii, table_selector_jq_friendly, min_val, max_val, col_num_visible, col_num_visible_iter, tmpStr, columnObjKey, columnObj, filters_position, unique_th, settingsDt, filterActionStr, custom_func_filter_value_holder, exclude_str, regex_str;
+      var $filter_selector, filter_selector_string, data, filter_container_id, column_number_data, column_number, column_position, filter_default_label, filter_reset_button_text, enable_auto_complete, date_format, ignore_char, filter_match_mode, column_data, column_data_temp, options_tmp, ii, table_selector_jq_friendly, min_val, max_val, col_num_visible, col_num_visible_iter, tmpStr, columnObjKey, columnObj, filters_position, unique_th, settingsDt, filterActionStr, custom_func_filter_value_holder, exclude_str, regex_str, null_str, externally_triggered_checkboxes_text, externally_triggered_checkboxes_function;
 
       if (pSettings === undefined) {
         settingsDt = getSettingsObjFromTable(oTable);
@@ -2716,6 +3075,8 @@ if (!Object.entries) {
           }
           filter_default_label = columnObj.filter_default_label;
           filter_reset_button_text = columnObj.filter_reset_button_text;
+          externally_triggered_checkboxes_text = columnObj.externally_triggered_checkboxes_text;
+          externally_triggered_checkboxes_function = columnObj.externally_triggered_checkboxes_function;
           enable_auto_complete = columnObj.enable_auto_complete;
           date_format = columnObj.date_format;
           if (columnObj.datepicker_type === 'jquery-ui') {
@@ -2743,15 +3104,15 @@ if (!Object.entries) {
 
           if (filter_default_label === undefined) {
             if (columnObj.filter_type === "select" || columnObj.filter_type === 'custom_func') {
-              filter_default_label = placeholderLang.select;
+              filter_default_label = default_options.language.select;
             } else if (columnObj.filter_type === "multi_select" || columnObj.filter_type === 'multi_select_custom_func') {
-              filter_default_label = placeholderLang.select_multi;
+              filter_default_label = default_options.language.select_multi;
             } else if (columnObj.filter_type === "auto_complete" || columnObj.filter_type === "text") {
-              filter_default_label = placeholderLang.filter;
+              filter_default_label = default_options.language.filter;
             } else if (columnObj.filter_type === "range_number" || columnObj.filter_type === "range_date") {
-              filter_default_label = placeholderLang.range;
+              filter_default_label = default_options.language.range;
             } else if (columnObj.filter_type === "date" || columnObj.filter_type === 'date_custom_func') {
-              filter_default_label = placeholderLang.date;
+              filter_default_label = default_options.language.date;
             }
             columnObj.filter_default_label = filter_default_label;
           }
@@ -2796,8 +3157,8 @@ if (!Object.entries) {
                     var cellDataRender = columnObj.column_number_render(getProp(column_data_render, indexData), 'filter', column_data, meta);
                     setProp(column_data_render, indexData, cellDataRender !== undefined && cellDataRender !== null ? cellDataRender : getProp(column_data, indexData));
                   } else {
-                    var _cellDataRender2 = columnObj.column_number_render(column_data_render[indexData], 'filter', column_data, meta);
-                    column_data_render[indexData] = _cellDataRender2 !== undefined && _cellDataRender2 !== null ? _cellDataRender2 : column_data[indexData];
+                    var _cellDataRender3 = columnObj.column_number_render(column_data_render[indexData], 'filter', column_data, meta);
+                    column_data_render[indexData] = _cellDataRender3 !== undefined && _cellDataRender3 !== null ? _cellDataRender3 : column_data[indexData];
                   }
                 });
               }
@@ -2907,11 +3268,11 @@ if (!Object.entries) {
                   tmpStr = settingsDt.aoPreSearchCols[column_position].sSearch;
                   if (columnObj.filter_type === "select") {
                     tmpStr = yadcfParseMatchFilter(tmpStr, getOptions(oTable.selector)[column_number].filter_match_mode);
-                    var filter = $('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number);
-                    var optionExists = filter.find("option[value='" + tmpStr + "']").length === 1;
-                    // Set the state preselected value only if the option exists in the select dropdown.
-                    if (optionExists) {
-                      filter.val(tmpStr).addClass("inuse");
+                    var foundEntry = $('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number + ' option').filter(function () {
+                      return $(this).val() === tmpStr;
+                    }).prop('selected', true);
+                    if (foundEntry && foundEntry.length > 0) {
+                      $('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number).addClass("inuse");
                     }
                   } else if (columnObj.filter_type === "multi_select") {
                     tmpStr = yadcfParseMatchFilterMultiSelect(tmpStr, getOptions(oTable.selector)[column_number].filter_match_mode);
@@ -2967,6 +3328,26 @@ if (!Object.entries) {
                 if (filter_reset_button_text !== false) {
                   $(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" " + "id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset\" onmousedown=\"yadcf.stopPropagation(event);\" onclick=\"yadcf.stopPropagation(event);yadcf.doFilter('clear', '" + table_selector_jq_friendly + "', " + column_number + "); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
                 }
+                if (columnObj.externally_triggered_checkboxes_text && typeof columnObj.externally_triggered_checkboxes_function === 'function') {
+                  $(filter_selector_string).append("<button type=\"button\" " + " id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-externally_triggered_checkboxes-button\" onmousedown=\"yadcf.stopPropagation(event);\" " + "onclick=\"yadcf.stopPropagation(event);\" class=\"yadcf-filter-externally_triggered_checkboxes-button " + columnObj.externally_triggered_checkboxes_button_style_class + "\">" + columnObj.externally_triggered_checkboxes_text + "</button>");
+                  $("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-externally_triggered_checkboxes-button").on('click', columnObj.externally_triggered_checkboxes_function);
+                }
+                exclude_str = '';
+                if (columnObj.exclude === true) {
+                  exclude_str = '<span class="yadcf-exclude-wrapper" onmousedown="yadcf.stopPropagation(event);" onclick="yadcf.stopPropagation(event);">' + '<div class="yadcf-label small">' + columnObj.exclude_label + '</div><input type="checkbox" title="' + columnObj.exclude_label + '" onclick="yadcf.stopPropagation(event);yadcf.doFilter(\'exclude\',\'' + table_selector_jq_friendly + '\',' + column_number + ', \'' + filter_match_mode + '\');"></span>';
+                }
+
+                exclude_str = columnObj.checkbox_position_after ? exclude_str.replace("yadcf-exclude-wrapper", "yadcf-exclude-wrapper after") : exclude_str;
+                if (columnObj.checkbox_position_after) {
+                  $(filter_selector_string).append(exclude_str);
+                } else {
+                  $(filter_selector_string).prepend(exclude_str);
+                }
+                // hide on load
+                if (columnObj.externally_triggered_checkboxes_text && typeof columnObj.externally_triggered_checkboxes_function === 'function') {
+                  var sel = $("#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number);
+                  sel.find('.yadcf-exclude-wrapper').hide();
+                }
               } else {
                 filterActionStr = 'onchange="yadcf.doFilterCustomDateFunc(this, \'' + table_selector_jq_friendly + '\', ' + column_number + ');"';
                 if (columnObj.externally_triggered === true) {
@@ -2995,11 +3376,55 @@ if (!Object.entries) {
               if (settingsDt.aoPreSearchCols[column_position].sSearch !== '') {
                 tmpStr = settingsDt.aoPreSearchCols[column_position].sSearch;
                 tmpStr = yadcfParseMatchFilter(tmpStr, getOptions(oTable.selector)[column_number].filter_match_mode);
-                var _filter = $('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number);
-                var _optionExists = _filter.find("option[value='" + tmpStr + "']").length === 1;
+                var match_mode = getOptions(oTable.selector)[column_number].filter_match_mode;
+                var _null_str = columnObj.select_null_option;
+                var excludeStrStart = "^((?!";
+                var excludeStrEnd = ").)*$";
+                switch (match_mode) {
+                  case "exact":
+                    _null_str = "^" + escapeRegExp(_null_str) + "$";
+                    excludeStrStart = "((?!^";
+                    excludeStrEnd = "$).)*";
+                    break;
+                  case "startsWith":
+                    _null_str = "^" + escapeRegExp(_null_str);
+                    excludeStrStart = "((?!^";
+                    excludeStrEnd = ").)*$";
+                    break;
+                  default:
+                    break;
+                }
+                _null_str = "^((?!" + _null_str + ").)*$";
+                _null_str = yadcfParseMatchFilter(_null_str, getOptions(oTable.selector)[column_number].filter_match_mode);
+
+                var exclude = false;
+                // null with exclude selected
+                if (_null_str === tmpStr) {
+                  exclude = true;
+                  tmpStr = columnObj.select_null_option;
+                } else if (tmpStr.includes(excludeStrStart) && tmpStr.includes(excludeStrEnd)) {
+                  exclude = true;
+                  tmpStr = tmpStr.replace(excludeStrStart, '');
+                  tmpStr = tmpStr.replace(excludeStrEnd, '');
+                }
+                var filter = $('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number);
+                tmpStr = escapeRegExp(tmpStr);
+                var optionExists = filter.find("option[value='" + tmpStr + "']").length === 1;
                 // Set the state preselected value only if the option exists in the select dropdown.
-                if (_optionExists) {
-                  _filter.val(tmpStr).addClass("inuse");
+                if (optionExists) {
+                  filter.val(tmpStr).addClass("inuse");
+                  if (exclude) {
+                    $('#yadcf-filter-wrapper-' + table_selector_jq_friendly + '-' + column_number).find('.yadcf-exclude-wrapper').find(':checkbox').prop('checked', true);
+                    $(document).data("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "_val", tmpStr);
+                    refreshSelectPlugin(columnObj, $("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number), tmpStr);
+                  }
+                  if (tmpStr === columnObj.select_null_option && settingsDt.oFeatures.bServerSide === false) {
+                    oTable.fnFilter("", column_number);
+                    addNullFilterCapability(table_selector_jq_friendly, column_number, true);
+                    oTable.fnDraw();
+                    $(document).data("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "_val", tmpStr);
+                    refreshSelectPlugin(columnObj, $("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number), tmpStr);
+                  }
                 }
               }
 
@@ -3117,11 +3542,33 @@ if (!Object.entries) {
                 }
               }
 
+              null_str = '';
+              if (columnObj.null_check_box === true) {
+                if (columnObj.externally_triggered !== true) {
+                  null_str = '<span class="yadcf-null-wrapper" onmousedown="yadcf.stopPropagation(event);" onclick="yadcf.stopPropagation(event);">' + '<div class="yadcf-label small">' + columnObj.null_label + '</div><input type="checkbox" title="' + columnObj.null_label + '" onclick="yadcf.stopPropagation(event);yadcf.nullChecked(event,\'' + table_selector_jq_friendly + '\',' + column_number + ');"></span>';
+                } else {
+                  null_str = '<span class="yadcf-null-wrapper" onmousedown="yadcf.stopPropagation(event);" onclick="yadcf.stopPropagation(event);">' + '<div class="yadcf-label small">' + columnObj.null_label + '</div><input type="checkbox" title="' + columnObj.null_label + '" onclick="yadcf.stopPropagation(event);yadcf.nullChecked(event,\'' + table_selector_jq_friendly + '\',' + column_number + ');"></span>';
+                }
+                if (oTable.fnSettings().oFeatures.bServerSide !== true) {
+                  addNullFilterCapability(table_selector_jq_friendly, column_number, false);
+                }
+              }
+
               var append_input = "<input type=\"text\" onkeydown=\"yadcf.preventDefaultForEnter(event);\" id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "\" class=\"yadcf-filter " + columnObj.style_class + "\" onmousedown=\"yadcf.stopPropagation(event);\" onclick='yadcf.stopPropagation(event);" + "' placeholder='" + filter_default_label + "'" + " filter_match_mode='" + filter_match_mode + "' " + filterActionStr + "></input>";
 
-              var append_checkboxes = columnObj.checkbox_position_after ? append_input + exclude_str.replace("yadcf-exclude-wrapper", "yadcf-exclude-wrapper after") + regex_str.replace("yadcf-regex-wrapper", "yadcf-regex-wrapper after") : exclude_str + regex_str + append_input;
+              var append_checkboxes = columnObj.checkbox_position_after ? append_input + exclude_str.replace("yadcf-exclude-wrapper", "yadcf-exclude-wrapper after") + regex_str.replace("yadcf-regex-wrapper", "yadcf-regex-wrapper after") + null_str.replace("yadcf-null-wrapper", "yadcf-null-wrapper after") : exclude_str + regex_str + null_str + append_input;
 
               $(filter_selector_string).append(append_checkboxes);
+
+              if (externally_triggered_checkboxes_text && typeof externally_triggered_checkboxes_function === 'function') {
+                var _sel = $("#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number);
+                // hide on load
+                _sel.find('.yadcf-exclude-wrapper').hide();
+                _sel.find('.yadcf-regex-wrapper').hide();
+                _sel.find('.yadcf-null-wrapper').hide();
+                $(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" " + " id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-externally_triggered_checkboxes-button\" onmousedown=\"yadcf.stopPropagation(event);\" " + "onclick=\"yadcf.stopPropagation(event);\" class=\"yadcf-filter-externally_triggered_checkboxes-button " + columnObj.externally_triggered_checkboxes_button_style_class + "\">" + externally_triggered_checkboxes_text + "</button>");
+                $("#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-externally_triggered_checkboxes-button").on('click', externally_triggered_checkboxes_function);
+              }
 
               if (filter_reset_button_text !== false) {
                 $(filter_selector_string).find(".yadcf-filter").after("<button type=\"button\" " + " id=\"yadcf-filter-" + table_selector_jq_friendly + "-" + column_number + "-reset\" onmousedown=\"yadcf.stopPropagation(event);\" " + "onclick=\"yadcf.stopPropagation(event);yadcf.textKeyUP(event,'" + table_selector_jq_friendly + "', '" + column_number + "', 'clear'); return false;\" class=\"yadcf-filter-reset-button " + columnObj.reset_button_style_class + "\">" + filter_reset_button_text + "</button>");
@@ -3173,6 +3620,22 @@ if (!Object.entries) {
     }
 
     function loadFromStateSaveTextFilter(oTable, settingsDt, columnObj, table_selector_jq_friendly, column_position, column_number) {
+      if (columnObj.null_check_box === true) {
+        if (settingsDt.oFeatures.bStateSave === true && settingsDt.oLoadedState) {
+          if (settingsDt.oLoadedState.yadcfState && settingsDt.oLoadedState.yadcfState[table_selector_jq_friendly] && settingsDt.oLoadedState.yadcfState[table_selector_jq_friendly][column_number]) {
+            if (settingsDt.oLoadedState.yadcfState[table_selector_jq_friendly][column_number].null_checked) {
+              $('#yadcf-filter-' + table_selector_jq_friendly + '-' + column_number).prop('disabled', true);
+              $('#yadcf-filter-wrapper-' + table_selector_jq_friendly + '-' + column_number).find('.yadcf-null-wrapper').find(':checkbox').prop('checked', true);
+            }
+            if (settingsDt.oLoadedState.yadcfState[table_selector_jq_friendly][column_number].exclude_checked) {
+              $('#yadcf-filter-wrapper-' + table_selector_jq_friendly + '-' + column_number).find('.yadcf-exclude-wrapper').find(':checkbox').prop('checked', true);
+            }
+            if (settingsDt.oLoadedState.yadcfState[table_selector_jq_friendly][column_number].null_checked) {
+              return;
+            }
+          }
+        }
+      }
       if (settingsDt.aoPreSearchCols[column_position].sSearch !== '') {
         var tmpStr = settingsDt.aoPreSearchCols[column_position].sSearch;
         if (columnObj.exclude === true) {
@@ -3215,15 +3678,25 @@ if (!Object.entries) {
       $.fn.dataTableExt.iApiIndex = oTablesIndex[table_selector_jq_friendly];
       event = eventTargetFixUp(event);
       settingsDt = getSettingsObjFromTable(oTable);
+      columnObj = getOptions(oTable.selector)[column_number];
 
       column_number_filter = calcColumnNumberFilter(settingsDt, column_number, table_selector_jq_friendly);
+      resetExcludeRegexCheckboxes($("#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number));
+      clearStateSave(oTable, column_number, table_selector_jq_friendly);
 
+      if (columnObj.null_check_box) {
+        $('#' + fromId.replace('-from-date-', '-from-')).prop('disabled', false);
+        $('#' + toId.replace('-to-date-', '-to-')).prop('disabled', false);
+        if (oTable.fnSettings().oFeatures.bServerSide !== true) {
+          oTable.fnDraw();
+        } else {
+          oTable.fnFilter("", column_number_filter);
+        }
+      }
       currentFilterValues = exGetColumnFilterVal(oTable, column_number);
       if (currentFilterValues.from === '' && currentFilterValues.to === '') {
         return;
       }
-
-      columnObj = getOptions(oTable.selector)[column_number];
 
       var buttonSelector = $(event.target).prop('nodeName') === 'BUTTON' ? $(event.target).parent() : $(event.target).parent().parent();
 
@@ -3266,12 +3739,15 @@ if (!Object.entries) {
       }
       resetIApiIndex();
 
-      buttonSelector.parent().find(".yadcf-filter-range").removeClass("inuse");
+      buttonSelector.parent().find(".yadcf-filter-range").removeClass("inuse inuse-exclude");
       if (columnObj.datepicker_type === 'bootstrap-datepicker') {
         $fromInput = $("#" + fromId);
         $toInput = $("#" + toId);
         $fromInput.datepicker('update');
         $toInput.datepicker('update');
+      } else if (columnObj.datepicker_type === 'jquery-ui') {
+        $("#" + fromId).datepicker('option', 'maxDate', null);
+        $("#" + toId).datepicker('option', 'minDate', null);
       }
 
       return;
@@ -3468,51 +3944,69 @@ if (!Object.entries) {
         columnObj,
         keyUp,
         settingsDt,
-        column_number_filter;
+        column_number_filter,
+        exclude_checked = false,
+        null_checked = false,
+        checkbox;
 
       event = eventTargetFixUp(event);
+      checkbox = $(event.target).attr('type') === 'checkbox';
+      var target = checkbox ? $(event.target).parent().parent().find('.yadcf-filter-range-number').first() : $(event.target);
       $.fn.dataTableExt.iApiIndex = oTablesIndex[table_selector_jq_friendly];
 
-      column_number = parseInt($(event.target).attr("id").replace('-from-', '').replace('-to-', '').replace('yadcf-filter-' + table_selector_jq_friendly, ''), 10);
+      column_number = parseInt(target.attr("id").replace('-from-', '').replace('-to-', '').replace('yadcf-filter-' + table_selector_jq_friendly, ''), 10);
       columnObj = getOptions(oTable.selector)[column_number];
       settingsDt = getSettingsObjFromTable(oTable);
       column_number_filter = calcColumnNumberFilter(settingsDt, column_number, table_selector_jq_friendly);
 
+      if (columnObj.exclude) {
+        exclude_checked = $("#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number).find('.yadcf-exclude-wrapper :checkbox').prop('checked');
+      }
+      // state save when exclude was fired last
+      if (columnObj.null_check_box) {
+        null_checked = $("#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number).find('.yadcf-null-wrapper :checkbox').prop('checked');
+      }
+
       keyUp = function keyUp() {
-        if (event.target.id.indexOf("-from-") !== -1) {
-          fromId = event.target.id;
-          toId = event.target.id.replace("-from-", "-to-");
-
-          min = document.getElementById(fromId).value;
-          max = document.getElementById(toId).value;
-        } else {
-          toId = event.target.id;
-          fromId = event.target.id.replace("-to-", "-from-");
-
-          max = document.getElementById(toId).value;
-          min = document.getElementById(fromId).value;
-        }
+        fromId = 'yadcf-filter-' + table_selector_jq_friendly + "-from-" + column_number;
+        toId = 'yadcf-filter-' + table_selector_jq_friendly + "-to-" + column_number;
+        min = document.getElementById(fromId).value;
+        max = document.getElementById(toId).value;
 
         min = min !== "" ? +min : min;
         max = max !== "" ? +max : max;
+
+        if (null_checked) {
+          if (oTable.fnSettings().oFeatures.bServerSide !== true) {
+            oTable.fnDraw();
+          } else {
+            var excludeString = columnObj.not_null_api_call_value ? columnObj.not_null_api_call_value : '!^@';
+            var nullString = columnObj.null_api_call_value ? columnObj.null_api_call_value : 'null';
+            var requestString = exclude_checked ? excludeString : nullString;
+            oTable.fnFilter(requestString, column_number_filter);
+          }
+          return;
+        }
 
         if (!isNaN(max) && !isNaN(min) && max >= min || min === "" || max === "") {
 
           if (oTable.fnSettings().oFeatures.bServerSide !== true) {
             oTable.fnDraw();
           } else {
-            oTable.fnFilter(min + columnObj.custom_range_delimiter + max, column_number_filter);
+            var exclude_delimeter = exclude_checked ? '!' : '';
+            oTable.fnFilter(exclude_delimeter + min + columnObj.custom_range_delimiter + max, column_number_filter);
           }
+          $("#" + fromId).removeClass("inuse inuse-exclude");
+          $("#" + toId).removeClass("inuse inuse-exclude");
+
+          var inuse_class = exclude_checked ? 'inuse inuse-exclude' : 'inuse';
           if (document.getElementById(fromId).value !== "") {
-            $("#" + fromId).addClass("inuse");
+            $("#" + fromId).addClass(inuse_class);
           }
           if (document.getElementById(toId).value !== "") {
-            $("#" + toId).addClass("inuse");
+            $("#" + toId).addClass(inuse_class);
           }
 
-          if ($.trim(event.target.value) === "" && $(event.target).hasClass("inuse")) {
-            $("#" + event.target.id).removeClass("inuse");
-          }
           if (!oTable.fnSettings().oLoadedState) {
             oTable.fnSettings().oLoadedState = {};
             oTable.fnSettings().oApi._fnSaveState(oTable.fnSettings());
@@ -3521,7 +4015,9 @@ if (!Object.entries) {
             if (oTable.fnSettings().oLoadedState.yadcfState !== undefined && oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly] !== undefined) {
               oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number] = {
                 from: min,
-                to: max
+                to: max,
+                exclude_checked: exclude_checked,
+                null_checked: null_checked
               };
             } else {
               yadcfState = {};
@@ -3641,16 +4137,16 @@ if (!Object.entries) {
       serachVal = event.target.value;
       smart = false;
       caseInsen = columnsObj.case_insensitive;
-      /*
-          if (columnsObj.filter_match_mode === "contains") {
-              regex = false;
-          } else if (columnsObj.filter_match_mode === "exact") {
-              regex = true;
-              serachVal = "^" + serachVal + "$";
-          } else if (columnsObj.filter_match_mode === "startsWith") {
-              regex = true;
-              serachVal = "^" + serachVal;
-          }*/
+			/*
+   		if (columnsObj.filter_match_mode === "contains") {
+   			regex = false;
+   		} else if (columnsObj.filter_match_mode === "exact") {
+   			regex = true;
+   			serachVal = "^" + serachVal + "$";
+   		} else if (columnsObj.filter_match_mode === "startsWith") {
+   			regex = true;
+   			serachVal = "^" + serachVal;
+   		}*/
       if (columnsObj.column_number instanceof Array) {
         tablesAsOne.columns(columnsObj.column_number).search(serachVal, regex, smart, caseInsen).draw();
       } else {
@@ -3695,17 +4191,17 @@ if (!Object.entries) {
         serachVal = event.target.value;
         smart = false;
         caseInsen = columnsObj.case_insensitive;
-        /*
-        if (columnsObj.filter_match_mode === "contains") {
-            regex = false;
-        } else if (columnsObj.filter_match_mode === "exact") {
-            regex = true;
-            serachVal = "^" + serachVal + "$";
-        } else if (columnsObj.filter_match_mode === "startsWith") {
-            regex = true;
-            serachVal = "^" + serachVal;
-        }
-*/
+				/*
+    			if (columnsObj.filter_match_mode === "contains") {
+    				regex = false;
+    			} else if (columnsObj.filter_match_mode === "exact") {
+    				regex = true;
+    				serachVal = "^" + serachVal + "$";
+    			} else if (columnsObj.filter_match_mode === "startsWith") {
+    				regex = true;
+    				serachVal = "^" + serachVal;
+    			}
+    */
         if (columnsObj.column_number instanceof Array) {
           tablesAsOne.columns(columnsObj.column_number).search(serachVal, regex, smart, caseInsen).draw();
         } else {
@@ -3730,6 +4226,7 @@ if (!Object.entries) {
         settingsDt = getSettingsObjFromTable(oTable),
         exclude,
         regex_check_box,
+        null_checked = false,
         yadcfState,
         keyCodes = [37, 38, 39, 40, 17];
 
@@ -3751,13 +4248,49 @@ if (!Object.entries) {
         }
         $.fn.dataTableExt.iApiIndex = oTablesIndex[table_selector_jq_friendly];
 
+        // chcek checkboxes
+        if (columnObj.null_check_box === true) {
+          null_checked = $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).closest('.yadcf-filter-wrapper').find('.yadcf-null-wrapper :checkbox').prop('checked');
+        }
+        if (columnObj.exclude === true) {
+          exclude = $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).closest('.yadcf-filter-wrapper').find('.yadcf-exclude-wrapper :checkbox').prop('checked');
+        }
+        if (columnObj.regex_check_box === true) {
+          regex_check_box = $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).closest('.yadcf-filter-wrapper').find('.yadcf-regex-wrapper :checkbox').prop('checked');
+        }
+
         if (clear === 'clear' || $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).val() === '') {
           if (clear === 'clear') {
             // uncheck checkboxes on reset button pressed
-            resetExcludeRegexCheckboxes($(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number));
+            resetExcludeRegexCheckboxes($(fixedPrefix + "#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number));
+            clearStateSave(oTable, column_number, table_selector_jq_friendly);
+            $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).prop('disabled', false);
+            if (columnObj.null_check_box) {
+              if (oTable.fnSettings().oFeatures.bServerSide !== true) {
+                oTable.fnDraw();
+              } else {
+                oTable.fnFilter("", column_number_filter);
+              }
+            }
             if (exGetColumnFilterVal(oTable, column_number) === '') {
               return;
             }
+          }
+
+          if (null_checked && columnObj.exclude) {
+            if (oTable.fnSettings().oFeatures.bServerSide === true) {
+              if (exclude) {
+                columnObj.not_null_api_call_value = columnObj.not_null_api_call_value ? columnObj.not_null_api_call_value : '!^@';
+                oTable.fnFilter(columnObj.not_null_api_call_value, column_number_filter);
+              } else {
+                columnObj.null_api_call_value = columnObj.null_api_call_value ? columnObj.null_api_call_value : 'null';
+                oTable.fnFilter(columnObj.null_api_call_value, column_number_filter);
+              }
+            } else {
+              oTable.fnDraw();
+            }
+            saveTextKeyUpState(oTable, table_selector_jq_friendly, column_number, regex_check_box, null_checked, exclude);
+            return;
           }
 
           $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).val("").focus();
@@ -3766,38 +4299,18 @@ if (!Object.entries) {
           resetIApiIndex();
           return;
         }
-        // delete class also on  regex or exclude checkbox uncheck
+        // delete class also on regex or exclude checkbox uncheck
         $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).removeClass("inuse-exclude inuse-regex");
         var inuseClass = "inuse";
+        inuseClass = exclude ? inuseClass + " inuse-exclude" : inuseClass;
+        inuseClass = regex_check_box ? inuseClass + " inuse-regex" : inuseClass;
 
-        if (columnObj.exclude === true) {
-          exclude = $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).closest('.yadcf-filter-wrapper').find('.yadcf-exclude-wrapper :checkbox').prop('checked');
-          inuseClass = exclude ? inuseClass + " inuse-exclude" : inuseClass;
-        }
-        if (columnObj.regex_check_box === true) {
-          regex_check_box = $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).closest('.yadcf-filter-wrapper').find('.yadcf-regex-wrapper :checkbox').prop('checked');
-          inuseClass = regex_check_box ? inuseClass + " inuse-regex" : inuseClass;
-        }
         $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).addClass(inuseClass);
 
         yadcfMatchFilter(oTable, $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).val(), regex_check_box ? 'regex' : columnObj.filter_match_mode, column_number_filter, exclude, column_number);
 
         // save regex_checkbox state
-        if (oTable.fnSettings().oFeatures.bStateSave === true) {
-          if (oTable.fnSettings().oLoadedState.yadcfState !== undefined && oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly] !== undefined) {
-            oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number] = {
-              regex_check_box: regex_check_box
-            };
-          } else {
-            yadcfState = {};
-            yadcfState[table_selector_jq_friendly] = [];
-            yadcfState[table_selector_jq_friendly][column_number] = {
-              regex_check_box: regex_check_box
-            };
-            oTable.fnSettings().oLoadedState.yadcfState = yadcfState;
-          }
-          oTable.fnSettings().oApi._fnSaveState(oTable.fnSettings());
-        }
+        saveTextKeyUpState(oTable, table_selector_jq_friendly, column_number, regex_check_box, null_checked, exclude);
         resetIApiIndex();
       };
 
@@ -3806,6 +4319,129 @@ if (!Object.entries) {
       } else {
         yadcfDelay(function () {
           keyUp(table_selector_jq_friendly, column_number, clear);
+        }, columnObj.filter_delay);
+      }
+    }
+
+    function saveTextKeyUpState(oTable, table_selector_jq_friendly, column_number, regex_check_box, null_checked, exclude) {
+      if (oTable.fnSettings().oFeatures.bStateSave === true && oTable.fnSettings().oLoadedState.yadcfState) {
+        if (oTable.fnSettings().oLoadedState.yadcfState !== undefined && oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly] !== undefined) {
+          oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number] = {
+            regex_check_box: regex_check_box,
+            null_checked: null_checked,
+            exclude_checked: exclude
+          };
+        } else {
+          yadcfState = {};
+          yadcfState[table_selector_jq_friendly] = [];
+          yadcfState[table_selector_jq_friendly][column_number] = {
+            regex_check_box: regex_check_box,
+            exclude_checked: exclude,
+            null_checked: null_checked
+          };
+          oTable.fnSettings().oLoadedState.yadcfState = yadcfState;
+        }
+        oTable.fnSettings().oApi._fnSaveState(oTable.fnSettings());
+      }
+    }
+
+    function nullChecked(ev, table_selector_jq_friendly, column_number) {
+      var column_number_filter,
+        oTable = oTables[table_selector_jq_friendly],
+        click,
+        columnObj,
+        settingsDt = getSettingsObjFromTable(oTable),
+        yadcfState,
+        null_checked,
+        exclude_checked = false;
+
+      column_number_filter = calcColumnNumberFilter(settingsDt, column_number, table_selector_jq_friendly);
+
+      columnObj = getOptions(oTable.selector)[column_number];
+
+      var fixedPrefix = '';
+      if (settingsDt._fixedHeader !== undefined && $('.fixedHeader-floating').is(":visible")) {
+        fixedPrefix = '.fixedHeader-floating ';
+      }
+      if (columnObj.filters_position === 'tfoot' && settingsDt.nScrollFoot) {
+        fixedPrefix = '.' + settingsDt.nScrollFoot.className + ' ';
+      }
+      null_checked = $(fixedPrefix + "#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number).find('.yadcf-null-wrapper :checkbox').prop('checked');
+      if (columnObj.exclude) {
+        exclude_checked = $(fixedPrefix + "#yadcf-filter-wrapper-" + table_selector_jq_friendly + "-" + column_number).find('.yadcf-exclude-wrapper :checkbox').prop('checked');
+      }
+
+      click = function click(table_selector_jq_friendly, column_number) {
+        // remove input data and inuse classes
+        var inner = columnObj.filter_type === "range_number" ? 'wrapper-inner-' : '';
+        var inner_input = columnObj.filter_type === "range_number" ? ' :input' : '';
+        var input = $('#yadcf-filter-' + inner + table_selector_jq_friendly + '-' + column_number + inner_input);
+        input.removeClass('inuse inuse-exclude inuse-regex');
+
+        if (columnObj.filter_type === "text") {
+          $(fixedPrefix + "#yadcf-filter-" + table_selector_jq_friendly + "-" + column_number).val("").focus();
+          if (oTable.fnSettings().oFeatures.bServerSide !== true) {
+            oTable.fnFilter('', column_number_filter);
+          }
+        }
+        if (columnObj.filter_type === "range_number") {
+          input.val("");
+          if (oTable.fnSettings().oFeatures.bServerSide !== true) {
+            oTable.fnDraw();
+          }
+        }
+        // disable inputs
+        if (!null_checked) {
+          input.prop('disabled', false);
+        } else {
+          input.prop('disabled', true);
+        }
+
+        //filter by null
+        if (oTable.fnSettings().oFeatures.bServerSide !== true) {
+          oTable.fnDraw();
+        } else {
+          if (null_checked) {
+            if (!exclude_checked) {
+              columnObj.null_api_call_value = columnObj.null_api_call_value ? columnObj.null_api_call_value : 'null';
+              oTable.fnFilter(columnObj.null_api_call_value, column_number_filter);
+            } else {
+              columnObj.not_null_api_call_value = columnObj.not_null_api_call_value ? columnObj.not_null_api_call_value : '!^@';
+              oTable.fnFilter(columnObj.not_null_api_call_value, column_number_filter);
+            }
+          } else {
+            oTable.fnFilter('', column_number_filter);
+          }
+        }
+
+        // save regex_checkbox state
+        if (oTable.fnSettings().oFeatures.bStateSave === true) {
+          if (oTable.fnSettings().oLoadedState) {
+            if (oTable.fnSettings().oLoadedState.yadcfState !== undefined && oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly] !== undefined) {
+              oTable.fnSettings().oLoadedState.yadcfState[table_selector_jq_friendly][column_number] = {
+                null_checked: null_checked,
+                exclude_checked: exclude_checked
+              };
+            } else {
+              yadcfState = {};
+              yadcfState[table_selector_jq_friendly] = [];
+              yadcfState[table_selector_jq_friendly][column_number] = {
+                null_checked: null_checked,
+                exclude_checked: exclude_checked
+              };
+              oTable.fnSettings().oLoadedState.yadcfState = yadcfState;
+            }
+          }
+          oTable.fnSettings().oApi._fnSaveState(oTable.fnSettings());
+        }
+        resetIApiIndex();
+      };
+
+      if (columnObj.filter_delay === undefined) {
+        click(table_selector_jq_friendly, column_number);
+      } else {
+        yadcfDelay(function () {
+          click(table_selector_jq_friendly, column_number);
         }, columnObj.filter_delay);
       }
     }
@@ -3918,6 +4554,12 @@ if (!Object.entries) {
                 }
               }
             }
+            if (dTXhrComplete !== undefined) {
+              yadcfDelay(function () {
+                dTXhrComplete();
+                dTXhrComplete = undefined;
+              }, 100);
+            }
           });
         }
       }
@@ -3928,13 +4570,13 @@ if (!Object.entries) {
           var columnObjKey = void 0;
           for (columnObjKey in args) {
             if (args.hasOwnProperty(columnObjKey)) {
-              var _columnObj = args[columnObjKey];
-              var column_number = _columnObj.column_number;
+              var columnObj = args[columnObjKey];
+              var column_number = columnObj.column_number;
               column_number = +column_number;
               var column_position = column_number;
               var _table_selector_jq_friendly = yadcf.generateTableSelectorJQFriendly2(oTable);
 
-              loadFromStateSaveTextFilter(oTable, settings, _columnObj, _table_selector_jq_friendly, column_position, column_number);
+              loadFromStateSaveTextFilter(oTable, settings, columnObj, _table_selector_jq_friendly, column_position, column_number);
             }
           }
         });
@@ -4030,15 +4672,6 @@ if (!Object.entries) {
       } else {
         params.filters_position = 'tfoot';
       }
-      if (params.language !== undefined) {
-        for (tmpParams in placeholderLang) {
-          if (placeholderLang.hasOwnProperty(tmpParams)) {
-            if (params.language[tmpParams] !== undefined) {
-              placeholderLang[tmpParams] = params.language[tmpParams];
-            }
-          }
-        }
-      }
       $(document).data(this.selector + "_filters_position", params.filters_position);
 
       if ($(this.selector).length === 1) {
@@ -4085,15 +4718,6 @@ if (!Object.entries) {
         params.filters_position = 'thead';
       } else {
         params.filters_position = 'tfoot';
-      }
-      if (params.language !== undefined) {
-        for (tmpParams in placeholderLang) {
-          if (placeholderLang.hasOwnProperty(tmpParams)) {
-            if (params.language[tmpParams] !== undefined) {
-              placeholderLang[tmpParams] = params.language[tmpParams];
-            }
-          }
-        }
       }
       $(document).data(instance.selector + "_filters_position", params.filters_position);
 
@@ -4475,7 +5099,7 @@ if (!Object.entries) {
               if (table_arg.fnSettings().oFeatures.bServerSide === true) {
                 min = filter_value.from;
                 max = filter_value.to;
-                table_arg.fnSettings().aoPreSearchCols[column_position].sSearch = min + columnObj.custom_range_delimiter + max;
+                table_arg.fnSettings().aoPreSearchCols[column_position].sSearch = min + optionsObj.custom_range_delimiter + max;
               }
               saveStateSave(table_arg, column_number, table_selector_jq_friendly, filter_value.from, filter_value.to);
               break;
@@ -4495,7 +5119,11 @@ if (!Object.entries) {
                 $('#' + toId).removeClass('inuse');
               }
               if (table_arg.fnSettings().oFeatures.bServerSide === true) {
-                table_arg.fnSettings().aoPreSearchCols[column_position].sSearch = filter_value.from + columnObj.custom_range_delimiter + filter_value.to;
+                var searchValue = (filter_value.from || filter_value.to)
+                  ? filter_value.from + optionsObj.custom_range_delimiter + filter_value.to
+                  : '';
+
+                table_arg.fnSettings().aoPreSearchCols[column_position].sSearch = searchValue;
               }
               saveStateSave(table_arg, column_number, table_selector_jq_friendly, filter_value.from, filter_value.to);
               break;
@@ -4528,7 +5156,7 @@ if (!Object.entries) {
                 $('#' + sliderId).slider('values', 1, filter_value.to);
               }
               if (table_arg.fnSettings().oFeatures.bServerSide === true) {
-                table_arg.fnSettings().aoPreSearchCols[column_position].sSearch = filter_value.from + columnObj.custom_range_delimiter + filter_value.to;
+                table_arg.fnSettings().aoPreSearchCols[column_position].sSearch = filter_value.from + optionsObj.custom_range_delimiter + filter_value.to;
               }
               saveStateSave(table_arg, column_number, table_selector_jq_friendly, filter_value.from, filter_value.to);
               break;
@@ -4715,6 +5343,8 @@ if (!Object.entries) {
 
           switch (optionsObj.filter_type) {
             case 'select':
+              resetExcludeRegexCheckboxes($filterElement.parent());
+              clearStateSave(table_arg, column_number, table_selector_jq_friendly);
             case 'custom_func':
               $filterElement.val('-1').removeClass('inuse');
               table_arg.fnSettings().aoPreSearchCols[column_number].sSearch = '';
@@ -4724,9 +5354,11 @@ if (!Object.entries) {
               break;
             case 'auto_complete':
             case 'text':
+              $filterElement.prop('disabled', false);
               $filterElement.val('').removeClass('inuse inuse-exclude inuse-regex');
               table_arg.fnSettings().aoPreSearchCols[column_number].sSearch = '';
-              resetExcludeRegexCheckboxes($filterElement);
+              resetExcludeRegexCheckboxes($filterElement.parent());
+              clearStateSave(table_arg, column_number, table_selector_jq_friendly);
               break;
             case 'date':
               $filterElement.val('').removeClass('inuse');
@@ -4759,13 +5391,16 @@ if (!Object.entries) {
             case 'range_number':
               fromId = 'yadcf-filter-' + table_selector_jq_friendly + '-from-' + column_number;
               toId = 'yadcf-filter-' + table_selector_jq_friendly + '-to-' + column_number;
+              $(selectorePrefix + '#' + fromId).prop('disabled', false);
               $(selectorePrefix + '#' + fromId).val('');
-              $(selectorePrefix + '#' + fromId).removeClass('inuse');
+              $(selectorePrefix + '#' + fromId).removeClass('inuse inuse-exclude');
+              $(selectorePrefix + '#' + toId).prop('disabled', false);
               $(selectorePrefix + '#' + toId).val('');
-              $(selectorePrefix + '#' + toId).removeClass('inuse');
+              $(selectorePrefix + '#' + toId).removeClass('inuse inuse-exclude');
               if (table_arg.fnSettings().oFeatures.bServerSide === true) {
                 table_arg.fnSettings().aoPreSearchCols[column_number].sSearch = '';
               }
+              resetExcludeRegexCheckboxes($(selectorePrefix + '#' + fromId).parent().parent());
               clearStateSave(table_arg, column_number, table_selector_jq_friendly);
               break;
             case 'range_number_slider':
@@ -4790,7 +5425,7 @@ if (!Object.entries) {
       if (noRedraw !== true) {
         //clear global filter
         settingsDt.oPreviousSearch.sSearch = '';
-        if (settingsDt.aanFeatures.f !== undefined) {
+        if (typeof settingsDt.aanFeatures.f !== 'undefined') {
           for (i = 0; i < settingsDt.aanFeatures.f.length; i++) {
             $('input', settingsDt.aanFeatures.f[i]).val('');
           }
@@ -4848,8 +5483,20 @@ if (!Object.entries) {
     }
 
     function resetExcludeRegexCheckboxes(selector) {
-      selector.closest('.yadcf-filter-wrapper').find('.yadcf-exclude-wrapper :checkbox').prop('checked', false);
-      selector.closest('.yadcf-filter-wrapper').find('.yadcf-regex-wrapper :checkbox').prop('checked', false);
+      selector.find('.yadcf-exclude-wrapper :checkbox').prop('checked', false);
+      selector.find('.yadcf-regex-wrapper :checkbox').prop('checked', false);
+      selector.find('.yadcf-null-wrapper :checkbox').prop('checked', false);
+    }
+
+    function exRefreshColumnFilterWithDataProp(table_arg, col_num, updatedData) {
+      if (table_arg.settings !== undefined) {
+        table_arg = table_arg.settings()[0].oInstance;
+      }
+      var columnsObj = getOptions(table_arg.selector);
+      var columnObj = columnsObj[col_num];
+      columnObj.data = updatedData;
+      var table_selector_jq_friendly = yadcf.generateTableSelectorJQFriendly2(table_arg);
+      refreshSelectPlugin(columnObj, $("#yadcf-filter-" + table_selector_jq_friendly + "-" + col_num));
     }
 
     return {
@@ -4859,6 +5506,7 @@ if (!Object.entries) {
       doFilterAutocomplete: doFilterAutocomplete,
       autocompleteKeyUP: autocompleteKeyUP,
       getOptions: getOptions,
+      initDefaults: initDefaults,
       rangeNumberKeyUP: rangeNumberKeyUP,
       rangeDateKeyUP: rangeDateKeyUP,
       rangeClear: rangeClear,
@@ -4870,6 +5518,7 @@ if (!Object.entries) {
       dateKeyUP: dateKeyUP,
       dateSelectSingle: dateSelectSingle,
       textKeyUP: textKeyUP,
+      nullChecked: nullChecked,
       doFilterCustomDateFunc: doFilterCustomDateFunc,
       eventTargetFixUp: eventTargetFixUp,
       initMultipleTables: initMultipleTables,
@@ -4882,11 +5531,13 @@ if (!Object.entries) {
       exResetFilters: exResetFilters,
       initSelectPluginCustomTriggers: initSelectPluginCustomTriggers,
       preventDefaultForEnter: preventDefaultForEnter,
-      generateTableSelectorJQFriendly2: generateTableSelectorJQFriendly2
+      generateTableSelectorJQFriendly2: generateTableSelectorJQFriendly2,
+      exRefreshColumnFilterWithDataProp: exRefreshColumnFilterWithDataProp,
+      initOnDtXhrComplete: initOnDtXhrComplete
     };
   }();
   if (window) {
     window.yadcf = yadcf;
   }
   return yadcf;
-  });
+});

--- a/DataTables.NetStandard.Enhanced/DataTables.NetStandard.Enhanced.csproj
+++ b/DataTables.NetStandard.Enhanced/DataTables.NetStandard.Enhanced.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DataTables.NetStandard" Version="1.0.0" />
+    <PackageReference Include="DataTables.NetStandard" Version="1.1.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
   </ItemGroup>
 

--- a/DataTables.NetStandard.Enhanced/DataTablesFilterConfiguration.cs
+++ b/DataTables.NetStandard.Enhanced/DataTablesFilterConfiguration.cs
@@ -30,16 +30,10 @@ namespace DataTables.NetStandard.Enhanced
         public string DefaultTextInputPlaceholderValue { get; set; } = "Type to filter";
 
         /// <summary>
-        /// Defines the default placerholder displayed in numeric range min value inputs.
+        /// Defines the default placerholder displayed in numeric range inputs.
         /// Can be used to localize the filter.
         /// </summary>
-        public string DefaultNumericRangeInputPlaceholderMinValue { get; set; } = "Min";
-
-        /// <summary>
-        /// Defines the default placerholder displayed in numeric range max value inputs.
-        /// Can be used to localize the filter.
-        /// </summary>
-        public string DefaultNumericRangeInputPlaceholderMaxValue { get; set; } = "Max";
+        public string DefaultNumericRangeInputPlaceholderValue { get; set; } = "From - To";
 
         /// <summary>
         /// Additional filter options used to initialize the yadcf DataTables filter system.

--- a/DataTables.NetStandard.Enhanced/DataTablesFilterConfiguration.cs
+++ b/DataTables.NetStandard.Enhanced/DataTablesFilterConfiguration.cs
@@ -30,6 +30,18 @@ namespace DataTables.NetStandard.Enhanced
         public string DefaultTextInputPlaceholderValue { get; set; } = "Type to filter";
 
         /// <summary>
+        /// Defines the default placerholder displayed in numeric range min value inputs.
+        /// Can be used to localize the filter.
+        /// </summary>
+        public string DefaultNumericRangeInputPlaceholderMinValue { get; set; } = "Min";
+
+        /// <summary>
+        /// Defines the default placerholder displayed in numeric range max value inputs.
+        /// Can be used to localize the filter.
+        /// </summary>
+        public string DefaultNumericRangeInputPlaceholderMaxValue { get; set; } = "Max";
+
+        /// <summary>
         /// Additional filter options used to initialize the yadcf DataTables filter system.
         /// </summary>
         public IDictionary<string, dynamic> AdditionalFilterOptions { get; set; } = new Dictionary<string, dynamic>();

--- a/DataTables.NetStandard.Enhanced/EnhancedDataTable.cs
+++ b/DataTables.NetStandard.Enhanced/EnhancedDataTable.cs
@@ -241,9 +241,19 @@ namespace DataTables.NetStandard.Enhanced
         {
             return (s) =>
             {
-                if (string.IsNullOrWhiteSpace(s) || !s.Contains(delimiter))
+                if (string.IsNullOrWhiteSpace(s))
                 {
                     return (e, s) => true;
+                }
+
+                if (!s.Contains(delimiter))
+                {
+                    if (long.TryParse(s, out long val))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, val, val);
+                    }
+
+                    return (e, s) => false;
                 }
 
                 var parts = s.Split(new string[] { delimiter }, StringSplitOptions.None);
@@ -286,9 +296,19 @@ namespace DataTables.NetStandard.Enhanced
         {
             return (s) =>
             {
-                if (string.IsNullOrWhiteSpace(s) || !s.Contains(delimiter))
+                if (string.IsNullOrWhiteSpace(s))
                 {
                     return (e, s) => true;
+                }
+
+                if (!s.Contains(delimiter))
+                {
+                    if (int.TryParse(s, out int val))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, val, val);
+                    }
+
+                    return (e, s) => false;
                 }
 
                 var parts = s.Split(new string[] { delimiter }, StringSplitOptions.None);

--- a/DataTables.NetStandard.Enhanced/Filters/NumericRangeFilter.cs
+++ b/DataTables.NetStandard.Enhanced/Filters/NumericRangeFilter.cs
@@ -1,37 +1,7 @@
-﻿using System.Collections.Generic;
-
-namespace DataTables.NetStandard.Enhanced.Filters
+﻿namespace DataTables.NetStandard.Enhanced.Filters
 {
-    public class NumericRangeFilter : BaseFilter, IColumnFilter
+    public class NumericRangeFilter : TextInputFilter
     {
-        /// <summary>
-        /// Defines the placeholder displayed on the input for the minimum value.
-        /// </summary>
-        public string PlaceholderMinValue { get; set; }
-
-        /// <summary>
-        /// Defines the placeholder displayed on the input for the maximum value.
-        /// </summary>
-        public string PlaceholderMaxValue { get; set; }
-
-        /// <summary>
-        /// Setting this to <c>true</c> enables a checkbox which allows filtering by <c>null</c>.
-        /// </summary>
-        public bool AllowFilteringByNull { get; set; }
-
-        public override string FilterType => "range_number";
-
         internal NumericRangeFilter() { }
-
-        public override FilterOptions GetFilterOptions(int columnIndex)
-        {
-            var options = base.GetFilterOptions(columnIndex, new Dictionary<string, dynamic>
-            {
-                { "filter_default_label", new string[] { PlaceholderMinValue, PlaceholderMaxValue } },
-                { "null_check_box", AllowFilteringByNull },
-            });
-
-            return options;
-        }
     }
 }

--- a/DataTables.NetStandard.Enhanced/Filters/NumericRangeFilter.cs
+++ b/DataTables.NetStandard.Enhanced/Filters/NumericRangeFilter.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+
+namespace DataTables.NetStandard.Enhanced.Filters
+{
+    public class NumericRangeFilter : BaseFilter, IColumnFilter
+    {
+        /// <summary>
+        /// Defines the placeholder displayed on the input for the minimum value.
+        /// </summary>
+        public string PlaceholderMinValue { get; set; }
+
+        /// <summary>
+        /// Defines the placeholder displayed on the input for the maximum value.
+        /// </summary>
+        public string PlaceholderMaxValue { get; set; }
+
+        /// <summary>
+        /// Setting this to <c>true</c> enables a checkbox which allows filtering by <c>null</c>.
+        /// </summary>
+        public bool AllowFilteringByNull { get; set; }
+
+        public override string FilterType => "range_number";
+
+        internal NumericRangeFilter() { }
+
+        public override FilterOptions GetFilterOptions(int columnIndex)
+        {
+            var options = base.GetFilterOptions(columnIndex, new Dictionary<string, dynamic>
+            {
+                { "filter_default_label", new string[] { PlaceholderMinValue, PlaceholderMaxValue } },
+                { "null_check_box", AllowFilteringByNull },
+            });
+
+            return options;
+        }
+    }
+}

--- a/DataTables.NetStandard.Enhanced/Util/PropertyHelper.cs
+++ b/DataTables.NetStandard.Enhanced/Util/PropertyHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace DataTables.NetStandard.Enhanced.Util
+{
+    /// <summary>
+    /// Provides useful methods to work with expressions and properties.
+    /// </summary>
+    /// <typeparam name="TEntity"></typeparam>
+    public static class PropertyHelper<TEntity>
+    {
+        /// <summary>
+        /// Retrieve the <see cref="PropertyInfo"/> of a property using the given <paramref name="selector"/>.
+        /// </summary>
+        /// <typeparam name="TValue"></typeparam>
+        /// <param name="selector"></param>
+        /// <returns></returns>
+        public static PropertyInfo GetProperty<TValue>(Expression<Func<TEntity, TValue>> selector)
+        {
+            Expression body = selector;
+
+            if (body is LambdaExpression)
+            {
+                body = ((LambdaExpression)body).Body;
+            }
+
+            switch (body.NodeType)
+            {
+                case ExpressionType.MemberAccess:
+                    return (PropertyInfo)((MemberExpression)body).Member;
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -140,6 +140,43 @@ new EnhancedDataTablesColumn<Person, PersonViewModel>
 
 _Please note that also the value of a `LabelValuePair` has always to be a string as the search of DataTables works with strings only._
 
+### NumericRangeFilter Filter
+
+Based on the `TextInputFilter`, the `NumericRangeFilter` allows searching for entities by entering a numeric range in one of the following forms:
+- `42-45` to select entities matching the values 42, 43, 44 and 45
+- `42-` to select entities matching the values 42 and above
+- `-42` to select entities matching the value 42 and below
+- `42` to select the entity matching the value 42
+- any other input like `foo` (i.e. not a number) will return zero results to make the user aware of the wrong input
+
+Defining the column filter alone will not be enough though. It only adds the filter to the table. In order to add the processing logic,
+the `ColumnSearchPredicateProvider` should be set to `CreateNumericRangeSearchPredicateProvider(p => p.Id)` where `p => p.Id` is the predicate
+selecting the column to filter on.
+
+```csharp
+new EnhancedDataTablesColumn<Person, PersonViewModel>
+{
+    PublicName = "id",
+    DisplayName = "ID",
+    PublicPropertyName = nameof(PersonViewModel.Id),
+    PrivatePropertyName = nameof(Person.Id),
+    IsOrderable = true,
+    IsSearchable = true,
+    SearchPredicate = (p, s) => s.Contains(p.Id.ToString()),
+    ColumnSearchPredicateProvider = CreateNumericRangeSearchPredicateProvider(p => p.Id),
+    ColumnFilter = CreateNumericRangeFilter()
+}
+```
+
+The delimiter used to define a range when inputting numbers may also be changed from `-` to something else by passing a different delimiter
+as second parameter to `CreateNumericRangeSearchPredicateProvider()`. This may be useful when searchability for negative numbers is required.
+
+_Note: using this setup, the global search will find individual entries with the searched ID, while the column search may be used to search
+for a range of IDs._
+
+_Note: currently, this filter can be used for `int` and `long` columns. Other numeric types are currently not supported, since parsing them
+is culture dependent._
+
 ## Filter Configuration
 
 When configuring your filters with additional options, you can always choose between configuring only one instance of a filter


### PR DESCRIPTION
This PR adds a new numeric range filter, which allows to search for single entities but also for ranges of entities using a simple text input as filter in the UI.

Based on the `TextInputFilter`, the `NumericRangeFilter` allows searching for entities by entering a numeric range in one of the following forms:
- `42-45` to select entities matching the values 42, 43, 44 and 45
- `42-` to select entities matching the values 42 and above
- `-42` to select entities matching the value 42 and below
- `42` to select the entity matching the value 42
- any other input like `foo` (i.e. not a number) will return zero results to make the user aware of the wrong input

Using the `NumericRangeFilter` (which is only the UI part), it is necessary to provide a custom filter logic. To make this simple, a new method `CreateNumericRangeSearchPredicateProvider(expr)` has been added to the `EnhancedDataTable`, which can be used like this:
```csharp
new EnhancedDataTablesColumn<Person, PersonViewModel>
{
    PublicName = "id",
    DisplayName = "ID",
    PublicPropertyName = nameof(PersonViewModel.Id),
    PrivatePropertyName = nameof(Person.Id),
    IsOrderable = true,
    IsSearchable = true,
    SearchPredicate = (p, s) => s.Contains(p.Id.ToString()),
    ColumnSearchPredicateProvider = CreateNumericRangeSearchPredicateProvider(p => p.Id),
    ColumnFilter = CreateNumericRangeFilter()
}
```
Currently, the `NumericRangeFilter` inherits from the `TextInputFilter` and comes with a different placeholder (configurable). That's the only difference between these two though.