### PR TITLE
Add new multi select filter

### DIFF
--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/BaseDataTable.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/BaseDataTable.cs
@@ -23,6 +23,7 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
         protected override void ConfigureFilters(DataTablesFilterConfiguration configuration)
         {
             configuration.DefaultSelectionLabelValue = "Select something";
+            configuration.DefaultMultiSelectionLabelValue = "All";
             configuration.DefaultTextInputPlaceholderValue = "Type to find";
 
             configuration.AdditionalFilterOptions.Add("filters_position", "footer");

--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
@@ -84,7 +84,8 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                     PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.PostCode)}",
                     IsOrderable = true,
                     IsSearchable = true,
-                    ColumnFilter = CreateSelectFilter(p => new LabelValuePair(p.Location.PostCode))
+                    SearchPredicateProvider = CreateMultiSelectSearchPredicateProvider(p => p.Location.PostCode),
+                    ColumnFilter = CreateMultiSelectFilter(p => new LabelValuePair(p.Location.PostCode))
                 },
                 new EnhancedDataTablesColumn<Person, PersonViewModel>
                 {
@@ -165,6 +166,7 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
             base.ConfigureFilters(configuration);
 
             configuration.DefaultSelectionLabelValue = "Select anything";
+            configuration.DefaultMultiSelectionLabelValue = "Select all";
         }
 
         protected override void ConfigureAdditionalOptions(DataTablesConfiguration configuration, IList<DataTablesColumn<Person, PersonViewModel>> columns)

--- a/DataTables.NetStandard.Enhanced/DataTablesFilterConfiguration.cs
+++ b/DataTables.NetStandard.Enhanced/DataTablesFilterConfiguration.cs
@@ -24,6 +24,12 @@ namespace DataTables.NetStandard.Enhanced
         public string DefaultSelectionLabelValue { get; set; } = "Select value";
 
         /// <summary>
+        /// Defines the default label displayed on multi select filters if <see cref="EnableDefaultSelectionLabel"/>
+        /// is enabled. Can be used to localize the filters.
+        /// </summary>
+        public string DefaultMultiSelectionLabelValue { get; set; } = "Select all";
+
+        /// <summary>
         /// Defines the default placerholder displayed in text inputs. Can be used to localize
         /// the filter.
         /// </summary>

--- a/DataTables.NetStandard.Enhanced/Filters/MultiSelectFilter.cs
+++ b/DataTables.NetStandard.Enhanced/Filters/MultiSelectFilter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace DataTables.NetStandard.Enhanced.Filters
+{
+    public class MultiSelectFilter<TEntity> : SelectFilter<TEntity>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SelectFilter{TEntity}"/> class.
+        /// </summary>
+        /// <param name="keyValueSelector">A selector used to load the filter options.</param>
+        internal MultiSelectFilter(Expression<Func<TEntity, LabelValuePair>> keyValueSelector) : base(keyValueSelector)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SelectFilter{TEntity}"/> class.
+        /// </summary>
+        /// <param name="filterOptions">The filter options.</param>
+        internal MultiSelectFilter(IList<LabelValuePair> filterOptions) : base(filterOptions)
+        {
+        }
+
+        public override string FilterType => "multi_select";
+    }
+}

--- a/DataTables.NetStandard.Enhanced/Util/PropertyHelper.cs
+++ b/DataTables.NetStandard.Enhanced/Util/PropertyHelper.cs
@@ -33,5 +33,32 @@ namespace DataTables.NetStandard.Enhanced.Util
                     throw new InvalidOperationException();
             }
         }
+
+        /// <summary>
+        /// Retrieve a <see cref="MemberExpression"/> from a property selector, which can also be a nested one.
+        /// </summary>
+        /// <param name="expression"></param>
+        /// <returns></returns>
+        public static MemberExpression GetMemberExpression(Expression expression)
+        {
+            if (expression is MemberExpression)
+            {
+                return (MemberExpression)expression;
+            }
+            
+            if (expression is LambdaExpression lambdaExpression)
+            {
+                if (lambdaExpression.Body is MemberExpression)
+                {
+                    return (MemberExpression)lambdaExpression.Body;
+                }
+                else if (lambdaExpression.Body is UnaryExpression)
+                {
+                    return ((MemberExpression)((UnaryExpression)lambdaExpression.Body).Operand);
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -140,6 +140,27 @@ new EnhancedDataTablesColumn<Person, PersonViewModel>
 
 _Please note that also the value of a `LabelValuePair` has always to be a string as the search of DataTables works with strings only._
 
+### MultiSelect Filter
+
+Similar to the `SelectFilter`, the `MultiSelectFilter` provides select options, but in a way that allows selecting multiple at once.
+Because processing of this filter requires custom logic on the server-side, a special search predicate provider is being provided
+to simplify the usage. The `CreateMultiSelectColumnSearchPredicateProvider(expr)` method takes one argument which is supposed to be
+an expression selecting a property, optionally a nested one:
+
+```csharp
+new EnhancedDataTablesColumn<Person, PersonViewModel>
+{
+    PublicName = "country",
+    DisplayName = "Country",
+    PublicPropertyName = nameof(PersonViewModel.Country),
+    PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.Country)}",
+    IsOrderable = true,
+    IsSearchable = true,
+    ColumnSearchPredicateProvider = CreateMultiSelectColumnSearchPredicateProvider(p => p.Location.Country),
+    ColumnFilter = CreateMultiSelectFilter(p => new LabelValuePair(p.Location.Country))
+}
+```
+
 ### NumericRange Filter
 
 Based on the `TextInputFilter`, the `NumericRangeFilter` allows searching for entities by entering a numeric range in one of the following forms:


### PR DESCRIPTION
This PR adds a new multi select filter based on the existing select filter, which allows to select multiple options at the same time.

Using the `MultiSelectFilter` (which is only the UI part), it is necessary to provide a custom filter logic. To make this simple, a new method `CreateMultiSelectColumnSearchPredicateProvider(expr)` has been added to the `EnhancedDataTable`, which can be used like this:
```cs
new EnhancedDataTablesColumn<Person, PersonViewModel>
{
    PublicName = "postCode",
    DisplayName = "Post Code",
    PublicPropertyName = nameof(PersonViewModel.PostCode),
    PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.PostCode)}",
    IsOrderable = true,
    IsSearchable = true,
    SearchPredicateProvider = CreateMultiSelectSearchPredicateProvider(p => p.Location.PostCode),
    ColumnFilter = CreateMultiSelectFilter(p => new LabelValuePair(p.Location.PostCode))
}
```

Currently, the `MultiSelectFilter` inherits from the `SelectFilter` and comes with a different placeholder (configurable).