### PR TITLE
Support nullable types for date range and numeric range filters

### DIFF
--- a/DataTables.NetStandard.Enhanced.Sample/DataTables.NetStandard.Enhanced.Sample.csproj
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables.NetStandard.Enhanced.Sample.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="AutoMapper" Version="10.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="DataTables.NetStandard.TemplateMapper" Version="1.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
@@ -67,6 +67,17 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                 },
                 new EnhancedDataTablesColumn<Person, PersonViewModel>
                 {
+                    PublicName = "locationId",
+                    DisplayName = "Location ID",
+                    PublicPropertyName = nameof(PersonViewModel.LocationId),
+                    PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.Id)}",
+                    IsOrderable = true,
+                    IsSearchable = true,
+                    ColumnSearchPredicateProvider = CreateNumericRangeSearchPredicateProvider(p => p.Location.Id),
+                    ColumnFilter = CreateNumericRangeFilter()
+                },
+                new EnhancedDataTablesColumn<Person, PersonViewModel>
+                {
                     PublicName = "address",
                     DisplayName = "Address",
                     PublicPropertyName = nameof(PersonViewModel.Address),

--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
@@ -115,11 +115,35 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                     PublicName = "fullAddress",
                     DisplayName = "Full Address",
                     PublicPropertyName = nameof(PersonViewModel.FullAddress),
-                    PrivatePropertyName = nameof(Person.Location.Id),
+                    PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.Id)}",
                     IsOrderable = true,
                     IsSearchable = true,
                     SearchPredicate = (p, s) => p.Location.Id.ToString() == s,
                     ColumnFilter = CreateSelectFilter(p => new LabelValuePair(p.Location.FullAddress, p.Location.Id.ToString()))
+                },
+                new EnhancedDataTablesColumn<Person, PersonViewModel>
+                {
+                    PublicName = "locationCreatedAt",
+                    DisplayName = "Location created at",
+                    PublicPropertyName = nameof(PersonViewModel.LocationCreatedAt),
+                    PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.CreatedAt)}",
+                    IsOrderable = true,
+                    IsSearchable = true,
+                    SearchPredicate = (p, s) => false,
+                    ColumnSearchPredicateProvider = CreateDateRangeSearchPredicateProvider(p => p.Location.CreatedAt),
+                    ColumnFilter = CreateDateRangeFilter()
+                },
+                new EnhancedDataTablesColumn<Person, PersonViewModel>
+                {
+                    PublicName = "locationUpdatedAt",
+                    DisplayName = "Location updated at",
+                    PublicPropertyName = nameof(PersonViewModel.LocationUpdatedAt),
+                    PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.UpdatedAt)}",
+                    IsOrderable = true,
+                    IsSearchable = true,
+                    SearchPredicate = (p, s) => false,
+                    ColumnSearchPredicateProvider = CreateDateRangeSearchPredicateProvider(p => p.Location.UpdatedAt),
+                    ColumnFilter = CreateDateRangeFilter()
                 },
                 new EnhancedDataTablesColumn<Person, PersonViewModel>
                 {

--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/ViewModels/DefaultMappingProfile.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/ViewModels/DefaultMappingProfile.cs
@@ -9,6 +9,7 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables.ViewModels
         public DefaultMappingProfile(IViewRenderService viewRenderService)
         {
             CreateMap<Person, PersonViewModel>()
+                .ForMember(vm => vm.LocationId, m => m.MapFrom(p => p.Location.Id))
                 .ForMember(vm => vm.Address, m => m.MapFrom(p => $"{p.Location.Street} {p.Location.HouseNumber}"))
                 .ForMember(vm => vm.PostCode, m => m.MapFrom(p => p.Location.PostCode))
                 .ForMember(vm => vm.City, m => m.MapFrom(p => p.Location.City))

--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/ViewModels/DefaultMappingProfile.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/ViewModels/DefaultMappingProfile.cs
@@ -14,6 +14,8 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables.ViewModels
                 .ForMember(vm => vm.City, m => m.MapFrom(p => p.Location.City))
                 .ForMember(vm => vm.Country, m => m.MapFrom(p => p.Location.Country))
                 .ForMember(vm => vm.FullAddress, m => m.MapFrom(p => p.Location.FullAddress))
+                .ForMember(vm => vm.LocationCreatedAt, m => m.MapFrom(p => p.Location.CreatedAt))
+                .ForMember(vm => vm.LocationUpdatedAt, m => m.MapFrom(p => p.Location.UpdatedAt))
 
                 // Raw columns containing some HTML (like action buttons) consist of simple strings. This means
                 // you can basically add a string column on the view model which does not have to exist on the

--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/ViewModels/PersonViewModel.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/ViewModels/PersonViewModel.cs
@@ -9,6 +9,7 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables.ViewModels
         public long Id { get; set; }
         public string Name { get; set; }
         public string Email { get; set; }
+        public long LocationId { get; set; }
         public string Address { get; set; }
         public string PostCode { get; set; }
         public string City { get; set; }

--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/ViewModels/PersonViewModel.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/ViewModels/PersonViewModel.cs
@@ -7,7 +7,6 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables.ViewModels
     public class PersonViewModel
     {
         public long Id { get; set; }
-
         public string Name { get; set; }
         public string Email { get; set; }
         public string Address { get; set; }
@@ -15,6 +14,10 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables.ViewModels
         public string City { get; set; }
         public string Country { get; set; }
         public string FullAddress { get; set; }
+        [JsonConverter(typeof(LocalDateTimeConverter), "dd.MM.yyyy HH:mm:ss")]
+        public DateTimeOffset LocationCreatedAt { get; set; }
+        [JsonConverter(typeof(LocalDateTimeConverter), "dd.MM.yyyy HH:mm:ss")]
+        public DateTimeOffset? LocationUpdatedAt { get; set; }
         public string Action { get; set; }
         public string Action2 { get; set; }
         public string Action3 { get; set; }

--- a/DataTables.NetStandard.Enhanced.Sample/Migrations/20200713121156_AddCreatedAtAndUpdatedAtColumnsToLocationsTable.Designer.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/Migrations/20200713121156_AddCreatedAtAndUpdatedAtColumnsToLocationsTable.Designer.cs
@@ -3,13 +3,15 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace DataTables.NetStandard.Enhanced.Sample.Migrations
 {
     [DbContext(typeof(SampleDbContext))]
-    partial class SampleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200713121156_AddCreatedAtAndUpdatedAtColumnsToLocationsTable")]
+    partial class AddCreatedAtAndUpdatedAtColumnsToLocationsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DataTables.NetStandard.Enhanced.Sample/Migrations/20200713121156_AddCreatedAtAndUpdatedAtColumnsToLocationsTable.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/Migrations/20200713121156_AddCreatedAtAndUpdatedAtColumnsToLocationsTable.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace DataTables.NetStandard.Enhanced.Sample.Migrations
+{
+    public partial class AddCreatedAtAndUpdatedAtColumnsToLocationsTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                table: "Locations",
+                nullable: false,
+                defaultValue: new DateTimeOffset(1, 1, 1, 0, 0, 0, new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAt",
+                table: "Locations",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                table: "Locations");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAt",
+                table: "Locations");
+        }
+    }
+}

--- a/DataTables.NetStandard.Enhanced.Sample/Models/Location.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/Models/Location.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace DataTables.NetStandard.Enhanced.Sample.Models
@@ -7,6 +8,8 @@ namespace DataTables.NetStandard.Enhanced.Sample.Models
     {
         [Key]
         public long Id { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset? UpdatedAt { get; set; }
         public string Street { get; set; }
         public string HouseNumber { get; set; }
         public string PostCode { get; set; }

--- a/DataTables.NetStandard.Enhanced/EnhancedDataTable.cs
+++ b/DataTables.NetStandard.Enhanced/EnhancedDataTable.cs
@@ -407,7 +407,7 @@ namespace DataTables.NetStandard.Enhanced
         /// <returns></returns>
         protected virtual Expression<Func<TEntity, string, bool>> BuildNumericRangeSearchExpression(Expression<Func<TEntity, long>> propertySelector, long? min, long? max)
         {
-            var entityParam = Expression.Parameter(typeof(TEntity), "e");
+            var entityParam = propertySelector.Parameters.First();
             var searchTermParam = Expression.Parameter(typeof(string), "s");
 
             var nullableMinConst = Expression.Constant(min, typeof(long?));
@@ -421,12 +421,12 @@ namespace DataTables.NetStandard.Enhanced
                     Expression.OrElse(
                         Expression.Equal(nullableMinConst, nullConst),
                         Expression.GreaterThanOrEqual(
-                            Expression.Property(entityParam, PropertyHelper<TEntity>.GetProperty(propertySelector)),
+                            PropertyHelper<TEntity>.GetMemberExpression(propertySelector),
                             minConst)),
                     Expression.OrElse(
                         Expression.Equal(nullableMaxConst, nullConst),
                         Expression.LessThanOrEqual(
-                            Expression.Property(entityParam, PropertyHelper<TEntity>.GetProperty(propertySelector)),
+                            PropertyHelper<TEntity>.GetMemberExpression(propertySelector),
                             maxConst))),
                 entityParam,
                 searchTermParam);
@@ -497,7 +497,7 @@ namespace DataTables.NetStandard.Enhanced
         /// <returns></returns>
         protected virtual Expression<Func<TEntity, string, bool>> BuildNumericRangeSearchExpression(Expression<Func<TEntity, int>> propertySelector, int? min, int? max)
         {
-            var entityParam = Expression.Parameter(typeof(TEntity), "e");
+            var entityParam = propertySelector.Parameters.First();
             var searchTermParam = Expression.Parameter(typeof(string), "s");
 
             var nullableMinConst = Expression.Constant(min, typeof(int?));
@@ -511,13 +511,197 @@ namespace DataTables.NetStandard.Enhanced
                     Expression.OrElse(
                         Expression.Equal(nullableMinConst, nullConst),
                         Expression.GreaterThanOrEqual(
-                            Expression.Property(entityParam, PropertyHelper<TEntity>.GetProperty(propertySelector)),
+                            PropertyHelper<TEntity>.GetMemberExpression(propertySelector),
                             minConst)),
                     Expression.OrElse(
                         Expression.Equal(nullableMaxConst, nullConst),
                         Expression.LessThanOrEqual(
-                            Expression.Property(entityParam, PropertyHelper<TEntity>.GetProperty(propertySelector)),
+                            PropertyHelper<TEntity>.GetMemberExpression(propertySelector),
                             maxConst))),
+                entityParam,
+                searchTermParam);
+        }
+
+        /// <summary>
+        /// Returns a numeric range search predicate provider expression for the given <paramref name="propertySelector"/>.
+        /// </summary>
+        /// <param name="propertySelector"></param>
+        /// <param name="delimiter"></param>
+        /// <returns></returns>
+        protected virtual Func<string, Expression<Func<TEntity, string, bool>>> CreateNumericRangeSearchPredicateProvider(
+            Expression<Func<TEntity, long?>> propertySelector, 
+            string delimiter = "-")
+        {
+            return (s) =>
+            {
+                if (string.IsNullOrWhiteSpace(s))
+                {
+                    return (e, s) => true;
+                }
+
+                if (!s.Contains(delimiter))
+                {
+                    if (long.TryParse(s, out long val))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, val, val);
+                    }
+
+                    return (e, s) => false;
+                }
+
+                var parts = s.Split(new string[] { delimiter }, StringSplitOptions.None);
+
+                if (!string.IsNullOrWhiteSpace(parts[0]) && !string.IsNullOrWhiteSpace(parts[1]))
+                {
+                    if (long.TryParse(parts[0], out long min) && long.TryParse(parts[1], out long max))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, min, max);
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(parts[0]))
+                {
+                    if (long.TryParse(parts[0], out long min))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, min, null);
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(parts[1]))
+                {
+                    if (long.TryParse(parts[1], out long max))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, null, max);
+                    }
+                }
+
+                return (e, s) => true;
+            };
+        }
+
+        /// <summary>
+        /// Builds a numeric range search expression using the given inputs. The expression will ignore borders set to <c>null</c>
+        /// while filtering the data.
+        /// </summary>
+        /// <param name="propertySelector"></param>
+        /// <param name="min"></param>
+        /// <param name="max"></param>
+        /// <returns></returns>
+        protected virtual Expression<Func<TEntity, string, bool>> BuildNumericRangeSearchExpression(
+            Expression<Func<TEntity, long?>> propertySelector, long? min, long? max)
+        {
+            var entityParam = propertySelector.Parameters.First();
+            var searchTermParam = Expression.Parameter(typeof(string), "s");
+
+            var nullableMinConst = Expression.Constant(min, typeof(long?));
+            var nullableMaxConst = Expression.Constant(max, typeof(long?));
+            var nullConst = Expression.Constant(null, typeof(long?));
+
+            return Expression.Lambda<Func<TEntity, string, bool>>(
+                Expression.AndAlso(
+                    Expression.OrElse(
+                        Expression.Equal(nullableMinConst, nullConst),
+                        Expression.GreaterThanOrEqual(
+                            PropertyHelper<TEntity>.GetMemberExpression(propertySelector),
+                            nullableMinConst)),
+                    Expression.OrElse(
+                        Expression.Equal(nullableMaxConst, nullConst),
+                        Expression.LessThanOrEqual(
+                            PropertyHelper<TEntity>.GetMemberExpression(propertySelector),
+                            nullableMaxConst))),
+                entityParam,
+                searchTermParam);
+        }
+
+        /// <summary>
+        /// Returns a numeric range search predicate provider expression for the given <paramref name="propertySelector"/>.
+        /// </summary>
+        /// <param name="propertySelector"></param>
+        /// <param name="delimiter"></param>
+        /// <returns></returns>
+        protected virtual Func<string, Expression<Func<TEntity, string, bool>>> CreateNumericRangeSearchPredicateProvider(
+            Expression<Func<TEntity, int?>> propertySelector, 
+            string delimiter = "-")
+        {
+            return (s) =>
+            {
+                if (string.IsNullOrWhiteSpace(s))
+                {
+                    return (e, s) => true;
+                }
+
+                if (!s.Contains(delimiter))
+                {
+                    if (int.TryParse(s, out int val))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, val, val);
+                    }
+
+                    return (e, s) => false;
+                }
+
+                var parts = s.Split(new string[] { delimiter }, StringSplitOptions.None);
+
+                if (!string.IsNullOrWhiteSpace(parts[0]) && !string.IsNullOrWhiteSpace(parts[1]))
+                {
+                    if (int.TryParse(parts[0], out int min) && int.TryParse(parts[1], out int max))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, min, max);
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(parts[0]))
+                {
+                    if (int.TryParse(parts[0], out int min))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, min, null);
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(parts[1]))
+                {
+                    if (int.TryParse(parts[1], out int max))
+                    {
+                        return BuildNumericRangeSearchExpression(propertySelector, null, max);
+                    }
+                }
+
+                return (e, s) => true;
+            };
+        }
+
+        /// <summary>
+        /// Builds a numeric range search expression using the given inputs. The expression will ignore borders set to <c>null</c>
+        /// while filtering the data.
+        /// </summary>
+        /// <param name="propertySelector"></param>
+        /// <param name="min"></param>
+        /// <param name="max"></param>
+        /// <returns></returns>
+        protected virtual Expression<Func<TEntity, string, bool>> BuildNumericRangeSearchExpression(
+            Expression<Func<TEntity, int?>> propertySelector, 
+            int? min, 
+            int? max)
+        {
+            var entityParam = propertySelector.Parameters.First();
+            var searchTermParam = Expression.Parameter(typeof(string), "s");
+
+            var nullableMinConst = Expression.Constant(min, typeof(int?));
+            var nullableMaxConst = Expression.Constant(max, typeof(int?));
+            var nullConst = Expression.Constant(null, typeof(int?));
+
+            return Expression.Lambda<Func<TEntity, string, bool>>(
+                Expression.AndAlso(
+                    Expression.OrElse(
+                        Expression.Equal(nullableMinConst, nullConst),
+                        Expression.GreaterThanOrEqual(
+                            PropertyHelper<TEntity>.GetMemberExpression(propertySelector),
+                            nullableMinConst)),
+                    Expression.OrElse(
+                        Expression.Equal(nullableMaxConst, nullConst),
+                        Expression.LessThanOrEqual(
+                            PropertyHelper<TEntity>.GetMemberExpression(propertySelector),
+                            nullableMaxConst))),
                 entityParam,
                 searchTermParam);
         }

--- a/DataTables.NetStandard.Enhanced/Util/PropertyHelper.cs
+++ b/DataTables.NetStandard.Enhanced/Util/PropertyHelper.cs
@@ -48,13 +48,14 @@ namespace DataTables.NetStandard.Enhanced.Util
             
             if (expression is LambdaExpression lambdaExpression)
             {
-                if (lambdaExpression.Body is MemberExpression)
+                if (lambdaExpression.Body is MemberExpression memberBody)
                 {
-                    return (MemberExpression)lambdaExpression.Body;
+                    return memberBody;
                 }
-                else if (lambdaExpression.Body is UnaryExpression)
+                
+                if (lambdaExpression.Body is UnaryExpression unaryBody)
                 {
-                    return ((MemberExpression)((UnaryExpression)lambdaExpression.Body).Operand);
+                    return (MemberExpression)unaryBody.Operand;
                 }
             }
 


### PR DESCRIPTION
This PR extends the `EnhancedDataTable` by factory methods for nullable date and numeric types for the respective date range and numeric range filters. The change also includes support for nested property selector expressions.

To demonstrate and test the changes, the sample project has been extended by a few nested columns.