### PR TITLE
Bump version to v1.2.0

### DIFF
--- a/DataTables.NetStandard.Enhanced/DataTables.NetStandard.Enhanced.csproj
+++ b/DataTables.NetStandard.Enhanced/DataTables.NetStandard.Enhanced.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     <Authors>Namoshek</Authors>
     <Company>Namoshek</Company>
     <PackageId>DataTables.NetStandard.Enhanced</PackageId>


### PR DESCRIPTION
This PR bumps the version to v1.2.0 since a few new fully backwards-compatible features were added since v1.1.0.