### PR TITLE
Update DataTables.NetStandard to 2.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,22 @@
 version: 2
+
 updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    labels:
+      - "nuget dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    labels:
+      - "github actions"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,32 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Test dotnet ${{ matrix.dotnet-version }}
+
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        dotnet-version: ['6.0.x']
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Setup .NET Core Build Environment
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Build package
-      run: dotnet build --configuration Release
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Build package
+        run: dotnet build --configuration 'Release'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,18 +8,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v1
-      - name: Setup .NET Core Build Environment
-        uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v3
         with:
-          dotnet-version: '3.1.x'
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+
       - name: Build packages
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration 'Release'
+
       - name: Pack NuGet packages
-        run: dotnet pack -c Release -o out
+        run: dotnet pack --configuration 'Release' --output 'out'
+
       - name: Push NuGet packages to nuget.org
-        run: dotnet nuget push **/*.nupkg
-               --api-key ${{ secrets.NUGET_API_KEY }}
-               --source https://api.nuget.org/v3/index.json
-               --skip-duplicate
+        run: dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/DataTables.NetStandard.Enhanced.Sample/DataTables.NetStandard.Enhanced.Sample.csproj
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables.NetStandard.Enhanced.Sample.csproj
@@ -1,16 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="DataTables.NetStandard.TemplateMapper" Version="1.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using AutoMapper;
 using DataTables.NetStandard.Enhanced.Filters;
@@ -130,7 +130,9 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                     IsOrderable = true,
                     IsSearchable = true,
                     SearchPredicate = (p, s) => p.Location.Id.ToString() == s,
-                    ColumnFilter = CreateSelectFilter(p => new LabelValuePair(p.Location.FullAddress, p.Location.Id.ToString()))
+                    ColumnFilter = CreateSelectFilter(p => new LabelValuePair(
+                        p.Location.Street + " " + p.Location.HouseNumber + ", " + p.Location.PostCode + " " + p.Location.City + " (" + p.Location.Country + ")",
+                        p.Location.Id.ToString()))
                 },
                 new EnhancedDataTablesColumn<Person, PersonViewModel>
                 {

--- a/DataTables.NetStandard.Enhanced/DataTables.NetStandard.Enhanced.csproj
+++ b/DataTables.NetStandard.Enhanced/DataTables.NetStandard.Enhanced.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.2.1</Version>
-    <AssemblyVersion>1.2.1.0</AssemblyVersion>
-    <FileVersion>1.2.1.0</FileVersion>
-    <Authors>Namoshek</Authors>
-    <Company>Namoshek</Company>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+    <Authors>Namoshek (Marvin Mall)</Authors>
+    <Company>Namoshek (Marvin Mall)</Company>
     <PackageId>DataTables.NetStandard.Enhanced</PackageId>
     <Description>Enhanced features for the self-containing DataTable classes for the datatables.net jQuery plugin that manage rendering, querying, filtering, sorting and other desireable tasks for the user.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DataTables.NetStandard" Version="1.1.0" />
+    <PackageReference Include="DataTables.NetStandard" Version="2.0.0" />
     <PackageReference Include="morelinq" Version="3.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates the dependency [`DataTables.NetStandard`](https://nuget.org/packages/DataTables.NetStandard) to version `2.0.0` which includes support for EFCore 6 and requires `netstandard2.1`. The update also includes a fix for query caching.