### PR TITLE
Change TargetFramework of sample project to net6.0

### DIFF
--- a/DataTables.NetStandard.Enhanced.Sample/DataTables.NetStandard.Enhanced.Sample.csproj
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables.NetStandard.Enhanced.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 


### PR DESCRIPTION
The target framework `netcoreapp6.0` seems to be an unofficially supported alias and was used by accident.