### PR TITLE
Fix filter expressions used to retrieve distinct column values

### DIFF
--- a/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Enhanced.Sample/DataTables/PersonDataTable.cs
@@ -121,7 +121,11 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                     IsOrderable = true,
                     IsSearchable = true,
                     SearchPredicateProvider = CreateMultiSelectSearchPredicateProvider(p => p.Location.PostCode),
-                    ColumnFilter = CreateMultiSelectFilter(p => new LabelValuePair(p.Location.PostCode))
+                    ColumnFilter = CreateMultiSelectFilter(p => new LabelValuePair
+                    {
+                        Label = p.Location.PostCode,
+                        Value = p.Location.PostCode
+                    })
                 },
                 new EnhancedDataTablesColumn<Person, PersonViewModel>
                 {
@@ -131,7 +135,11 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                     PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.City)}",
                     IsOrderable = true,
                     IsSearchable = true,
-                    ColumnFilter = CreateSelectFilter(p => new LabelValuePair(p.Location.City))
+                    ColumnFilter = CreateMultiSelectFilter(p => new LabelValuePair
+                    {
+                        Label = p.Location.City,
+                        Value = p.Location.City
+                    })
                 },
                 new EnhancedDataTablesColumn<Person, PersonViewModel>
                 {
@@ -141,7 +149,11 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                     PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.Country)}",
                     IsOrderable = true,
                     IsSearchable = true,
-                    ColumnFilter = CreateSelectFilter(p => new LabelValuePair(p.Location.Country), p =>
+                    ColumnFilter = CreateSelectFilter(p => new LabelValuePair
+                    {
+                        Label = p.Location.Country,
+                        Value = p.Location.Country
+                    }, p =>
                     {
                         p.DefaultSelectionLabelValue = "Choose something";
                     })
@@ -155,9 +167,11 @@ namespace DataTables.NetStandard.Enhanced.Sample.DataTables
                     IsOrderable = true,
                     IsSearchable = true,
                     SearchPredicate = (p, s) => p.Location.Id.ToString() == s,
-                    ColumnFilter = CreateSelectFilter(p => new LabelValuePair(
-                        p.Location.Street + " " + p.Location.HouseNumber + ", " + p.Location.PostCode + " " + p.Location.City + " (" + p.Location.Country + ")",
-                        p.Location.Id.ToString()))
+                    ColumnFilter = CreateSelectFilter(p => new LabelValuePair
+                    {
+                        Label = p.Location.Street + " " + p.Location.HouseNumber + ", " + p.Location.PostCode + " " + p.Location.City + " (" + p.Location.Country + ")",
+                        Value = p.Location.Id.ToString()
+                    })
                 },
                 new EnhancedDataTablesColumn<Person, PersonViewModel>
                 {

--- a/DataTables.NetStandard.Enhanced/DataTables.NetStandard.Enhanced.csproj
+++ b/DataTables.NetStandard.Enhanced/DataTables.NetStandard.Enhanced.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.0.0</Version>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <FileVersion>2.0.0.0</FileVersion>
+    <Version>3.0.0</Version>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
+    <FileVersion>3.0.0.0</FileVersion>
     <Authors>Namoshek (Marvin Mall)</Authors>
     <Company>Namoshek (Marvin Mall)</Company>
     <PackageId>DataTables.NetStandard.Enhanced</PackageId>
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DataTables.NetStandard" Version="2.0.0" />
+    <PackageReference Include="DataTables.NetStandard" Version="3.0.1" />
     <PackageReference Include="morelinq" Version="3.3.2" />
   </ItemGroup>
 

--- a/DataTables.NetStandard.Enhanced/EnhancedDataTable.cs
+++ b/DataTables.NetStandard.Enhanced/EnhancedDataTable.cs
@@ -156,8 +156,9 @@ namespace DataTables.NetStandard.Enhanced
             }
 
             return query
-                .Select(selector.Compile())
-                .DistinctBy(e => e.Value)
+                .Select(selector)
+                .GroupBy(e => e.Value)
+                .Select(g => g.First())
                 .ToList();
         }
         

--- a/DataTables.NetStandard.Enhanced/Filters/LabelValuePair.cs
+++ b/DataTables.NetStandard.Enhanced/Filters/LabelValuePair.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+using System.Linq.Expressions;
+using Newtonsoft.Json;
 
 namespace DataTables.NetStandard.Enhanced.Filters
 {
@@ -9,6 +10,14 @@ namespace DataTables.NetStandard.Enhanced.Filters
 
         [JsonProperty(PropertyName = "label")]
         public string Label { get; set; }
+
+        /// <summary>
+        /// A default constructor to be used in expressions which are translated to SQL,
+        /// e.g. <see cref="EnhancedDataTable{TEntity, TEntityViewModel}.CreateSelectFilter(Expression{System.Func{TEntity, LabelValuePair}}, System.Action{SelectFilter{TEntity}})"/>.
+        /// </summary>
+        public LabelValuePair()
+        {
+        }
 
         public LabelValuePair(string labelAndValue)
         {


### PR DESCRIPTION
To improve query performance by evaluating expressions in SQL, it was necessary to add a default constructor to `LabelValuePair` which has to be used in expressions translated to SQL.